### PR TITLE
build: enforce @ alias imports

### DIFF
--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -2,17 +2,17 @@
 // ABOUTME: Validates spreadsheet identifier and maps repository results to JSON.
 import { NextResponse } from "next/server";
 
-import { getSession } from "../../../server/auth/session";
-import { createSheetsClient } from "../../../server/google/clients";
+import { getSession } from "@/server/auth/session";
+import { createSheetsClient } from "@/server/google/clients";
 import {
   createAccountsRepository,
   type AccountRecord,
   type AccountsDiagnostics,
-} from "../../../server/google/repository/accounts-repository";
+} from "@/server/google/repository/accounts-repository";
 import {
   createSnapshotsRepository,
   type SnapshotRecord,
-} from "../../../server/google/repository/snapshots-repository";
+} from "@/server/google/repository/snapshots-repository";
 
 interface FetchAccountsOptions {
   spreadsheetId: string;

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Connects handlers to shared Google auth configuration.
 import NextAuth from "next-auth";
 
-import { authConfig } from "../../../../server/auth/config";
+import { authConfig } from "@/server/auth/config";
 
 const handler = NextAuth(authConfig);
 

--- a/src/app/api/budget-plan/route.ts
+++ b/src/app/api/budget-plan/route.ts
@@ -2,12 +2,12 @@
 // ABOUTME: Validates spreadsheet identifier query string and proxies repository data.
 import { NextResponse } from "next/server";
 
-import { getSession } from "../../../server/auth/session";
-import { createSheetsClient } from "../../../server/google/clients";
+import { getSession } from "@/server/auth/session";
+import { createSheetsClient } from "@/server/google/clients";
 import {
   createBudgetPlanRepository,
   type BudgetPlanRecord,
-} from "../../../server/google/repository/budget-plan-repository";
+} from "@/server/google/repository/budget-plan-repository";
 
 interface FetchBudgetPlanOptions {
   spreadsheetId: string;

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -2,12 +2,12 @@
 // ABOUTME: Validates spreadsheet identifier and maps repository results to JSON.
 import { NextResponse } from "next/server";
 
-import { getSession } from "../../../server/auth/session";
-import { createSheetsClient } from "../../../server/google/clients";
+import { getSession } from "@/server/auth/session";
+import { createSheetsClient } from "@/server/google/clients";
 import {
   createCategoriesRepository,
   type CategoryRecord,
-} from "../../../server/google/repository/categories-repository";
+} from "@/server/google/repository/categories-repository";
 
 interface FetchCategoriesOptions {
   spreadsheetId: string;

--- a/src/app/api/snapshots/route.ts
+++ b/src/app/api/snapshots/route.ts
@@ -3,16 +3,16 @@
 import { NextResponse } from "next/server";
 import { randomUUID } from "node:crypto";
 
-import { getSession } from "../../../server/auth/session";
-import { createSheetsClient } from "../../../server/google/clients";
+import { getSession } from "@/server/auth/session";
+import { createSheetsClient } from "@/server/google/clients";
 import {
   createSnapshotsRepository,
   type SnapshotRecord,
-} from "../../../server/google/repository/snapshots-repository";
+} from "@/server/google/repository/snapshots-repository";
 import {
   createAccountsRepository,
   type AccountRecord,
-} from "../../../server/google/repository/accounts-repository";
+} from "@/server/google/repository/accounts-repository";
 
 interface FetchSnapshotsOptions {
   spreadsheetId: string;

--- a/src/app/api/spreadsheet/bootstrap/route.ts
+++ b/src/app/api/spreadsheet/bootstrap/route.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Validates requests and returns refreshed manifest details.
 import { NextResponse } from "next/server";
 
-import { bootstrapExistingSpreadsheet } from "../../../../server/google/bootstrap";
+import { bootstrapExistingSpreadsheet } from "@/server/google/bootstrap";
 
 type BootstrapHandler = typeof bootstrapExistingSpreadsheet;
 

--- a/src/app/api/spreadsheet/create/route.ts
+++ b/src/app/api/spreadsheet/create/route.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Returns manifest payload after Drive creation succeeds.
 import { NextResponse } from "next/server";
 
-import { createAndRegisterSpreadsheet } from "../../../../server/google/create-spreadsheet";
+import { createAndRegisterSpreadsheet } from "@/server/google/create-spreadsheet";
 
 type CreateAndRegister = typeof createAndRegisterSpreadsheet;
 

--- a/src/app/api/spreadsheet/register/route.ts
+++ b/src/app/api/spreadsheet/register/route.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Persists manifest metadata and returns selection manifest.
 import { NextResponse } from "next/server";
 
-import { registerSpreadsheetSelection } from "../../../../server/google/register-spreadsheet";
+import { registerSpreadsheetSelection } from "@/server/google/register-spreadsheet";
 
 interface RegisterBody {
   spreadsheetId?: string;

--- a/src/server/google/bootstrap.ts
+++ b/src/server/google/bootstrap.ts
@@ -4,7 +4,7 @@ import type { Session } from "next-auth";
 
 import type { sheets_v4 } from "googleapis";
 
-import { getSession } from "../auth/session";
+import { getSession } from "@/server/auth/session";
 import { createSheetsClient, type GoogleAuthTokens } from "./clients";
 import { executeWithRetry } from "./retry";
 import {

--- a/src/server/google/create-spreadsheet.ts
+++ b/src/server/google/create-spreadsheet.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Reuses session tokens to persist manifest metadata.
 import type { Session } from "next-auth";
 
-import { getSession } from "../auth/session";
+import { getSession } from "@/server/auth/session";
 
 import type { GoogleAuthTokens } from "./clients";
 import { createSpreadsheet as createDriveSpreadsheet } from "./drive";

--- a/src/server/google/register-spreadsheet.ts
+++ b/src/server/google/register-spreadsheet.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Persists manifest metadata to the Sheets `_meta` tab.
 import type { Session } from "next-auth";
 
-import { getSession } from "../auth/session";
+import { getSession } from "@/server/auth/session";
 
 import type { sheets_v4 } from "googleapis";
 

--- a/src/server/google/repository/accounts-repository.ts
+++ b/src/server/google/repository/accounts-repository.ts
@@ -2,8 +2,8 @@
 // ABOUTME: Applies schema validation and boolean/date normalization for rows.
 import type { sheets_v4 } from "googleapis";
 
-import { executeWithRetry } from "../retry";
-import { ACCOUNTS_SHEET_SCHEMA, dataRange } from "../sheet-schemas";
+import { executeWithRetry } from "@/server/google/retry";
+import { ACCOUNTS_SHEET_SCHEMA, dataRange } from "@/server/google/sheet-schemas";
 import {
   ensureHeaderRow,
   isEmptyRow,

--- a/src/server/google/repository/actuals-repository.ts
+++ b/src/server/google/repository/actuals-repository.ts
@@ -2,8 +2,8 @@
 // ABOUTME: Validates numeric amounts and required transaction fields.
 import type { sheets_v4 } from "googleapis";
 
-import { executeWithRetry } from "../retry";
-import { ACTUALS_SHEET_SCHEMA, dataRange } from "../sheet-schemas";
+import { executeWithRetry } from "@/server/google/retry";
+import { ACTUALS_SHEET_SCHEMA, dataRange } from "@/server/google/sheet-schemas";
 import {
   ensureHeaderRow,
   isEmptyRow,

--- a/src/server/google/repository/budget-plan-repository.ts
+++ b/src/server/google/repository/budget-plan-repository.ts
@@ -2,8 +2,8 @@
 // ABOUTME: Validates numeric fields and normalizes rollover balances.
 import type { sheets_v4 } from "googleapis";
 
-import { executeWithRetry } from "../retry";
-import { BUDGET_PLAN_SHEET_SCHEMA, dataRange } from "../sheet-schemas";
+import { executeWithRetry } from "@/server/google/retry";
+import { BUDGET_PLAN_SHEET_SCHEMA, dataRange } from "@/server/google/sheet-schemas";
 import {
   ensureHeaderRow,
   isEmptyRow,

--- a/src/server/google/repository/categories-repository.ts
+++ b/src/server/google/repository/categories-repository.ts
@@ -2,8 +2,8 @@
 // ABOUTME: Validates sheet rows and maps them to typed category structures.
 import type { sheets_v4 } from "googleapis";
 
-import { executeWithRetry } from "../retry";
-import { CATEGORIES_SHEET_SCHEMA, dataRange } from "../sheet-schemas";
+import { executeWithRetry } from "@/server/google/retry";
+import { CATEGORIES_SHEET_SCHEMA, dataRange } from "@/server/google/sheet-schemas";
 import {
   ensureHeaderRow as assertHeaderRow,
   isEmptyRow,

--- a/src/server/google/repository/future-events-repository.ts
+++ b/src/server/google/repository/future-events-repository.ts
@@ -2,8 +2,8 @@
 // ABOUTME: Validates required scheduling fields and normalizes numeric amounts.
 import type { sheets_v4 } from "googleapis";
 
-import { executeWithRetry } from "../retry";
-import { FUTURE_EVENTS_SHEET_SCHEMA, dataRange } from "../sheet-schemas";
+import { executeWithRetry } from "@/server/google/retry";
+import { FUTURE_EVENTS_SHEET_SCHEMA, dataRange } from "@/server/google/sheet-schemas";
 import {
   ensureHeaderRow,
   isEmptyRow,

--- a/src/server/google/repository/meta-repository.ts
+++ b/src/server/google/repository/meta-repository.ts
@@ -2,13 +2,13 @@
 // ABOUTME: Normalizes meta rows for spreadsheet bootstrap workflows.
 import type { sheets_v4 } from "googleapis";
 
-import { executeWithRetry } from "../retry";
+import { executeWithRetry } from "@/server/google/retry";
 import {
   META_HEADERS,
   META_SHEET_SCHEMA,
   META_SHEET_TITLE,
   dataRange,
-} from "../sheet-schemas";
+} from "@/server/google/sheet-schemas";
 
 const META_VALUES_RANGE = `${META_SHEET_TITLE}!A1:B100`;
 

--- a/src/server/google/repository/runway-projection-repository.ts
+++ b/src/server/google/repository/runway-projection-repository.ts
@@ -2,8 +2,8 @@
 // ABOUTME: Validates numeric balances and ensures stoplight status is present.
 import type { sheets_v4 } from "googleapis";
 
-import { executeWithRetry } from "../retry";
-import { RUNWAY_PROJECTION_SHEET_SCHEMA, dataRange } from "../sheet-schemas";
+import { executeWithRetry } from "@/server/google/retry";
+import { RUNWAY_PROJECTION_SHEET_SCHEMA, dataRange } from "@/server/google/sheet-schemas";
 import {
   ensureHeaderRow,
   isEmptyRow,

--- a/src/server/google/repository/snapshots-repository.ts
+++ b/src/server/google/repository/snapshots-repository.ts
@@ -2,8 +2,8 @@
 // ABOUTME: Ensures balances parse to numbers and notes default to empty strings.
 import type { sheets_v4 } from "googleapis";
 
-import { executeWithRetry } from "../retry";
-import { SNAPSHOTS_SHEET_SCHEMA, dataRange } from "../sheet-schemas";
+import { executeWithRetry } from "@/server/google/retry";
+import { SNAPSHOTS_SHEET_SCHEMA, dataRange } from "@/server/google/sheet-schemas";
 import {
   ensureHeaderRow,
   isEmptyRow,

--- a/tests/account-diagnostics.test.cjs
+++ b/tests/account-diagnostics.test.cjs
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 test("normalizeAccountWarnings extracts rows and messages with severity", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { normalizeAccountWarnings, isAccountWarning } = await jiti.import(
     "../src/components/accounts/account-diagnostics",
   );
@@ -26,7 +26,7 @@ test("normalizeAccountWarnings extracts rows and messages with severity", async 
 });
 
 test("normalizeAccountWarnings returns empty array for non-array input", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { normalizeAccountWarnings } = await jiti.import(
     "../src/components/accounts/account-diagnostics",
   );
@@ -36,7 +36,7 @@ test("normalizeAccountWarnings returns empty array for non-array input", async (
 });
 
 test("normalizeAccountErrors extracts codes and messages", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { normalizeAccountErrors, isAccountError } = await jiti.import(
     "../src/components/accounts/account-diagnostics",
   );

--- a/tests/accounts-repository.test.cjs
+++ b/tests/accounts-repository.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
   const getCalls = [];
@@ -44,7 +44,7 @@ function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
 }
 
 test("accounts repository list returns typed records", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, getCalls } = createSheetsStub({
     values: [
       [
@@ -99,7 +99,7 @@ test("accounts repository list returns typed records", async () => {
 });
 
 test("accounts repository listWithDiagnostics coerces invalid sort order and emits warnings", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub } = createSheetsStub({
     values: [
       [
@@ -159,7 +159,7 @@ test("accounts repository listWithDiagnostics coerces invalid sort order and emi
 });
 
 test("accounts repository listWithDiagnostics returns missing sheet error when tab absent", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub } = createSheetsStub({ throwsOnGet: true });
 
   const { createAccountsRepository } = await jiti.import(
@@ -184,7 +184,7 @@ test("accounts repository listWithDiagnostics returns missing sheet error when t
 });
 
 test("accounts repository listWithDiagnostics returns header mismatch error and skips rows", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub } = createSheetsStub({
     values: [
       [
@@ -222,7 +222,7 @@ test("accounts repository listWithDiagnostics returns header mismatch error and 
 });
 
 test("accounts repository list validates required fields", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub } = createSheetsStub({
     values: [
       [
@@ -251,7 +251,7 @@ test("accounts repository list validates required fields", async () => {
 });
 
 test("accounts repository save writes header and rows", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, updateCalls, getStoredValues } = createSheetsStub({
     values: [
       [

--- a/tests/accounts-route.test.cjs
+++ b/tests/accounts-route.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function withEnv(run) {
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
@@ -22,7 +22,7 @@ function withEnv(run) {
 
 test("accounts route requires spreadsheetId query", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createAccountsHandler } = await jiti.import(
       "../src/app/api/accounts/route",
     );
@@ -44,7 +44,7 @@ test("accounts route requires spreadsheetId query", async () => {
 
 test("accounts route maps auth errors to 401", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createAccountsHandler } = await jiti.import(
       "../src/app/api/accounts/route",
     );
@@ -66,7 +66,7 @@ test("accounts route maps auth errors to 401", async () => {
 
 test("accounts route returns data on success with warnings and errors", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createAccountsHandler } = await jiti.import(
       "../src/app/api/accounts/route",
     );
@@ -139,7 +139,7 @@ test("accounts route returns data on success with warnings and errors", async ()
 
 test("accounts update route requires spreadsheetId query", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createAccountsHandler } = await jiti.import(
       "../src/app/api/accounts/route",
     );
@@ -166,7 +166,7 @@ test("accounts update route requires spreadsheetId query", async () => {
 
 test("accounts update route validates payload shape", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createAccountsHandler } = await jiti.import(
       "../src/app/api/accounts/route",
     );
@@ -193,7 +193,7 @@ test("accounts update route validates payload shape", async () => {
 
 test("accounts update route persists records and returns payload with diagnostics", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createAccountsHandler } = await jiti.import(
       "../src/app/api/accounts/route",
     );
@@ -294,7 +294,7 @@ test("accounts update route persists records and returns payload with diagnostic
 
 test("accounts update route removes snapshots for deleted accounts", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createAccountsHandler } = await jiti.import(
       "../src/app/api/accounts/route",
     );

--- a/tests/actuals-repository.test.cjs
+++ b/tests/actuals-repository.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
   const getCalls = [];
@@ -44,7 +44,7 @@ function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
 }
 
 test("actuals repository list returns typed transactions", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, getCalls } = createSheetsStub({
     values: [
       ["txn_id", "account_id", "date", "category_id", "amount", "status", "entry_mode", "note"],
@@ -93,7 +93,7 @@ test("actuals repository list returns typed transactions", async () => {
 });
 
 test("actuals repository list validates required fields", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub } = createSheetsStub({
     values: [
       ["txn_id", "account_id", "date", "category_id", "amount", "status", "entry_mode", "note"],
@@ -114,7 +114,7 @@ test("actuals repository list validates required fields", async () => {
 });
 
 test("actuals repository save writes header and rows", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, updateCalls, getStoredValues } = createSheetsStub({
     values: [
       ["txn_id", "account_id", "date", "category_id", "amount", "status", "entry_mode", "note"],

--- a/tests/auth-config.test.cjs
+++ b/tests/auth-config.test.cjs
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 const REQUIRED_SCOPE = [
   "openid",
@@ -14,7 +14,7 @@ const REQUIRED_SCOPE = [
 ].join(" ");
 
 test("authConfig configures Google provider with required scopes", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
   const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
@@ -50,7 +50,7 @@ test("authConfig configures Google provider with required scopes", async () => {
 });
 
 test("authConfig jwt callback stores Google tokens", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
   const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
@@ -96,7 +96,7 @@ test("authConfig jwt callback stores Google tokens", async () => {
 });
 
 test("authConfig session callback attaches Google tokens", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
   const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
@@ -129,7 +129,7 @@ test("authConfig session callback attaches Google tokens", async () => {
 });
 
 test("authConfig jwt callback retains existing refresh token", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
   const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
 

--- a/tests/auth-route.test.cjs
+++ b/tests/auth-route.test.cjs
@@ -4,12 +4,12 @@
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
 const path = require("node:path");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 test("auth route wires NextAuth with shared config", async () => {
   const stubPath = path.resolve(__dirname, "./fixtures/next-auth-stub.cjs");
   const googleProviderPath = require.resolve("next-auth/providers/google");
-  const jiti = createJiti(__filename, {
+  const jiti = createTestJiti(__filename, {
     alias: {
       "next-auth": stubPath,
       "next-auth/providers/google": googleProviderPath,

--- a/tests/auth-session.test.cjs
+++ b/tests/auth-session.test.cjs
@@ -3,10 +3,10 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 test("requireSession returns server session when present", async () => {
-  const loader = createJiti(__filename);
+  const loader = createTestJiti(__filename);
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
   const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
@@ -27,7 +27,7 @@ test("requireSession returns server session when present", async () => {
 });
 
 test("requireSession redirects when session missing", async () => {
-  const loader = createJiti(__filename);
+  const loader = createTestJiti(__filename);
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
   const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
 

--- a/tests/bootstrap-route.test.cjs
+++ b/tests/bootstrap-route.test.cjs
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function withEnv(run) {
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
@@ -24,7 +24,7 @@ function withEnv(run) {
 
 test("bootstrap route validates request payload", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createBootstrapHandler } = await jiti.import(
       "../src/app/api/spreadsheet/bootstrap/route",
     );
@@ -47,7 +47,7 @@ test("bootstrap route validates request payload", async () => {
 
 test("bootstrap route maps auth failures to 401", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createBootstrapHandler } = await jiti.import(
       "../src/app/api/spreadsheet/bootstrap/route",
     );
@@ -74,7 +74,7 @@ test("bootstrap route maps auth failures to 401", async () => {
 
 test("bootstrap route returns manifest on success", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createBootstrapHandler } = await jiti.import(
       "../src/app/api/spreadsheet/bootstrap/route",
     );
@@ -111,7 +111,7 @@ test("bootstrap route returns manifest on success", async () => {
 
 test("bootstrap route maps unexpected errors to 500", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createBootstrapHandler } = await jiti.import(
       "../src/app/api/spreadsheet/bootstrap/route",
     );

--- a/tests/bootstrap-spreadsheet.test.cjs
+++ b/tests/bootstrap-spreadsheet.test.cjs
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function withEnv(run) {
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
@@ -105,7 +105,7 @@ function createSheetsStub({ existingSheets = [], sheetValues = {} } = {}) {
 
 test("bootstrapSpreadsheet creates meta sheet and rows when missing", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { stub, batchUpdateCalls, valueUpdateCalls } = createSheetsStub({
       existingSheets: DATA_SHEETS,
     });
@@ -167,7 +167,7 @@ test("bootstrapSpreadsheet creates meta sheet and rows when missing", async () =
 
 test("bootstrapSpreadsheet preserves existing keys and selected id", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const existingValues = [
       ["selected_spreadsheet_id", "sheet-existing"],
       ["custom_key", "custom"],
@@ -208,7 +208,7 @@ test("bootstrapSpreadsheet preserves existing keys and selected id", async () =>
 
 test("bootstrapExistingSpreadsheet requires authenticated session", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
 
     const { bootstrapExistingSpreadsheet } = await jiti.import(
       "../src/server/google/bootstrap",
@@ -227,7 +227,7 @@ test("bootstrapExistingSpreadsheet requires authenticated session", async () => 
 
 test("bootstrapExistingSpreadsheet requires Google tokens", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
 
     const { bootstrapExistingSpreadsheet } = await jiti.import(
       "../src/server/google/bootstrap",
@@ -246,7 +246,7 @@ test("bootstrapExistingSpreadsheet requires Google tokens", async () => {
 
 test("bootstrapExistingSpreadsheet bootstraps via Sheets client", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const bootstrapCalls = [];
     let receivedTokens;
 
@@ -303,7 +303,7 @@ test("bootstrapExistingSpreadsheet bootstraps via Sheets client", async () => {
 
 test("bootstrapSpreadsheet ensures data sheets exist with headers", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { stub, batchUpdateCalls, valueUpdateCalls } = createSheetsStub({
       existingSheets: [],
     });

--- a/tests/budget-plan-repository.test.cjs
+++ b/tests/budget-plan-repository.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
   const getCalls = [];
@@ -44,7 +44,7 @@ function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
 }
 
 test("budget plan repository list returns typed records", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, getCalls } = createSheetsStub({
     values: [
       ["record_id", "category_id", "month", "year", "amount", "rollover_balance"],
@@ -89,7 +89,7 @@ test("budget plan repository list returns typed records", async () => {
 });
 
 test("budget plan repository list validates required fields", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub } = createSheetsStub({
     values: [
       ["record_id", "category_id", "month", "year", "amount", "rollover_balance"],
@@ -110,7 +110,7 @@ test("budget plan repository list validates required fields", async () => {
 });
 
 test("budget plan repository save writes header and rows", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, updateCalls, getStoredValues } = createSheetsStub({
     values: [
       ["record_id", "category_id", "month", "year", "amount", "rollover_balance"],

--- a/tests/budget-plan-route.test.cjs
+++ b/tests/budget-plan-route.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function withEnv(run) {
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
@@ -22,7 +22,7 @@ function withEnv(run) {
 
 test("budget plan route requires spreadsheetId query", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createBudgetPlanHandler } = await jiti.import(
       "../src/app/api/budget-plan/route",
     );
@@ -44,7 +44,7 @@ test("budget plan route requires spreadsheetId query", async () => {
 
 test("budget plan route maps auth errors to 401", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createBudgetPlanHandler } = await jiti.import(
       "../src/app/api/budget-plan/route",
     );
@@ -66,7 +66,7 @@ test("budget plan route maps auth errors to 401", async () => {
 
 test("budget plan route returns data on success", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createBudgetPlanHandler } = await jiti.import(
       "../src/app/api/budget-plan/route",
     );
@@ -109,7 +109,7 @@ test("budget plan route returns data on success", async () => {
 
 test("budget plan update route requires spreadsheetId query", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createBudgetPlanHandler } = await jiti.import(
       "../src/app/api/budget-plan/route",
     );
@@ -136,7 +136,7 @@ test("budget plan update route requires spreadsheetId query", async () => {
 
 test("budget plan update route validates payload shape", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createBudgetPlanHandler } = await jiti.import(
       "../src/app/api/budget-plan/route",
     );
@@ -163,7 +163,7 @@ test("budget plan update route validates payload shape", async () => {
 
 test("budget plan update route persists records and returns payload", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createBudgetPlanHandler } = await jiti.import(
       "../src/app/api/budget-plan/route",
     );

--- a/tests/categories-repository.test.cjs
+++ b/tests/categories-repository.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
   const getCalls = [];
@@ -44,7 +44,7 @@ function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
 }
 
 test("categories repository list returns typed records", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, getCalls } = createSheetsStub({
     values: [
       ["category_id", "label", "color", "rollover_flag", "sort_order", "monthly_budget", "currency_code"],
@@ -91,7 +91,7 @@ test("categories repository list returns typed records", async () => {
 });
 
 test("categories repository list filters empty or malformed rows", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub } = createSheetsStub({
     values: [
       ["category_id", "label", "color", "rollover_flag", "sort_order", "monthly_budget", "currency_code"],
@@ -114,7 +114,7 @@ test("categories repository list filters empty or malformed rows", async () => {
 });
 
 test("categories repository list retries transient errors", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub } = createSheetsStub({
     values: [
       ["category_id", "label", "color", "rollover_flag", "sort_order", "monthly_budget", "currency_code"],
@@ -164,7 +164,7 @@ test("categories repository list retries transient errors", async () => {
 });
 
 test("categories repository save persists header and rows", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, updateCalls, getStoredValues } = createSheetsStub({
     values: [["category_id", "label", "color", "rollover_flag", "sort_order", "monthly_budget", "currency_code"]],
   });

--- a/tests/categories-route.test.cjs
+++ b/tests/categories-route.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function withEnv(run) {
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
@@ -22,7 +22,7 @@ function withEnv(run) {
 
 test("categories route requires spreadsheetId query", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createCategoriesHandler } = await jiti.import(
       "../src/app/api/categories/route",
     );
@@ -44,7 +44,7 @@ test("categories route requires spreadsheetId query", async () => {
 
 test("categories route maps auth errors to 401", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createCategoriesHandler } = await jiti.import(
       "../src/app/api/categories/route",
     );
@@ -66,7 +66,7 @@ test("categories route maps auth errors to 401", async () => {
 
 test("categories route returns data on success", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createCategoriesHandler } = await jiti.import(
       "../src/app/api/categories/route",
     );
@@ -111,7 +111,7 @@ test("categories route returns data on success", async () => {
 
 test("categories update route requires spreadsheetId query", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createCategoriesHandler } = await jiti.import(
       "../src/app/api/categories/route",
     );
@@ -138,7 +138,7 @@ test("categories update route requires spreadsheetId query", async () => {
 
 test("categories update route validates payload shape", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createCategoriesHandler } = await jiti.import(
       "../src/app/api/categories/route",
     );
@@ -165,7 +165,7 @@ test("categories update route validates payload shape", async () => {
 
 test("categories update route persists records and returns payload", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createCategoriesHandler } = await jiti.import(
       "../src/app/api/categories/route",
     );

--- a/tests/category-helpers.test.cjs
+++ b/tests/category-helpers.test.cjs
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 test("createBlankCategory generates defaults", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { createBlankCategory } = await jiti.import(
     "../src/components/categories/category-helpers",
   );
@@ -21,7 +21,7 @@ test("createBlankCategory generates defaults", async () => {
 });
 
 test("categoriesEqual compares drafts shallowly", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { categoriesEqual } = await jiti.import(
     "../src/components/categories/category-helpers",
   );

--- a/tests/create-spreadsheet-route.test.cjs
+++ b/tests/create-spreadsheet-route.test.cjs
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function withEnv(run) {
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
@@ -24,7 +24,7 @@ function withEnv(run) {
 
 test("create route maps auth failures to 401", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createCreateHandler } = await jiti.import(
       "../src/app/api/spreadsheet/create/route",
     );
@@ -45,7 +45,7 @@ test("create route maps auth failures to 401", async () => {
 
 test("create route returns manifest on success", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createCreateHandler } = await jiti.import(
       "../src/app/api/spreadsheet/create/route",
     );
@@ -69,7 +69,7 @@ test("create route returns manifest on success", async () => {
 
 test("create route maps unexpected errors to 500", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createCreateHandler } = await jiti.import(
       "../src/app/api/spreadsheet/create/route",
     );

--- a/tests/create-spreadsheet.test.cjs
+++ b/tests/create-spreadsheet.test.cjs
@@ -3,10 +3,10 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 test("createAndRegisterSpreadsheet requires authenticated session", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
   const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
@@ -32,7 +32,7 @@ test("createAndRegisterSpreadsheet requires authenticated session", async () => 
 });
 
 test("createAndRegisterSpreadsheet requires Google tokens", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
   const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
@@ -58,7 +58,7 @@ test("createAndRegisterSpreadsheet requires Google tokens", async () => {
 });
 
 test("createAndRegisterSpreadsheet creates and registers manifest", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
   const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
   const createCalls = [];

--- a/tests/currency-utils.test.cjs
+++ b/tests/currency-utils.test.cjs
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 test("convertCurrency converts using USD base", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { convertCurrency } = await jiti.import("../src/lib/currency");
 
   const rates = {
@@ -20,7 +20,7 @@ test("convertCurrency converts using USD base", async () => {
 });
 
 test("convertCurrency throws when rate missing", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { convertCurrency } = await jiti.import("../src/lib/currency");
 
   assert.throws(() =>
@@ -32,7 +32,7 @@ test("convertCurrency throws when rate missing", async () => {
 });
 
 test("formatCurrency supports approximation flag", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { formatCurrency } = await jiti.import("../src/lib/currency");
 
   assert.equal(formatCurrency(1234.5, "USD"), "$1,234.50");

--- a/tests/dev-log-route.test.cjs
+++ b/tests/dev-log-route.test.cjs
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function withEnv(debugFlag, run) {
   const original = process.env.DEBUG_LOGS;
@@ -24,7 +24,7 @@ function withEnv(debugFlag, run) {
 
 test("dev log route ignores requests when disabled", async () => {
   await withEnv(undefined, async () => {
-    const route = await createJiti(__filename, { cache: false }).import(
+    const route = await createTestJiti(__filename, { cache: false }).import(
       "../src/app/api/dev-log/route",
     );
 
@@ -50,7 +50,7 @@ test("dev log route logs when enabled", async () => {
   };
 
   await withEnv("true", async () => {
-    const route = await createJiti(__filename, { cache: false }).import(
+    const route = await createTestJiti(__filename, { cache: false }).import(
       "../src/app/api/dev-log/route",
     );
 

--- a/tests/exchange-rates-route.test.cjs
+++ b/tests/exchange-rates-route.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createResponse(status, json) {
   return {
@@ -14,7 +14,7 @@ function createResponse(status, json) {
 }
 
 test("exchange rates route returns fetched rates with caching headers", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { createExchangeRatesHandler } = await jiti.import(
     "../src/app/api/exchange-rates/route",
   );
@@ -49,7 +49,7 @@ test("exchange rates route returns fetched rates with caching headers", async ()
 });
 
 test("exchange rates route falls back on error", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { createExchangeRatesHandler, FALLBACK_RATES } = await jiti.import(
     "../src/app/api/exchange-rates/route",
   );
@@ -65,7 +65,7 @@ test("exchange rates route falls back on error", async () => {
 });
 
 test("exchange rates route falls back when payload missing rates", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { createExchangeRatesHandler, FALLBACK_RATES } = await jiti.import(
     "../src/app/api/exchange-rates/route",
   );

--- a/tests/exchange-rates-utils.test.cjs
+++ b/tests/exchange-rates-utils.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createResponse(status, json) {
   return {
@@ -14,7 +14,7 @@ function createResponse(status, json) {
 }
 
 test("loadExchangeRates returns parsed rates", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { loadExchangeRates, EXCHANGE_RATES_ENDPOINT } = await jiti.import(
     "../src/lib/exchange-rates",
   );
@@ -32,14 +32,14 @@ test("loadExchangeRates returns parsed rates", async () => {
 });
 
 test("loadExchangeRates throws on missing rates", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { loadExchangeRates } = await jiti.import("../src/lib/exchange-rates");
 
   await assert.rejects(() => loadExchangeRates(async () => createResponse(200, { foo: "bar" })), /Missing rates/);
 });
 
 test("loadExchangeRates throws on non-ok response", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { loadExchangeRates } = await jiti.import("../src/lib/exchange-rates");
 
   await assert.rejects(() => loadExchangeRates(async () => createResponse(500, {})), /Failed to load/);

--- a/tests/future-events-repository.test.cjs
+++ b/tests/future-events-repository.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
   const getCalls = [];
@@ -44,7 +44,7 @@ function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
 }
 
 test("future events repository list returns typed records", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, getCalls } = createSheetsStub({
     values: [
       [
@@ -130,7 +130,7 @@ test("future events repository list returns typed records", async () => {
 });
 
 test("future events repository list validates required fields", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub } = createSheetsStub({
     values: [
       [
@@ -162,7 +162,7 @@ test("future events repository list validates required fields", async () => {
 });
 
 test("future events repository save writes header and rows", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, updateCalls, getStoredValues } = createSheetsStub({
     values: [
       [

--- a/tests/google-clients.test.cjs
+++ b/tests/google-clients.test.cjs
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createGoogleStub() {
   const credentialsLog = [];
@@ -34,7 +34,7 @@ function createGoogleStub() {
 }
 
 test("createSheetsClient configures OAuth credentials", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const googleStub = createGoogleStub();
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
   const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
@@ -72,7 +72,7 @@ test("createSheetsClient configures OAuth credentials", async () => {
 });
 
 test("storeSelectedSpreadsheetMeta writes key-value pair", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const getCalls = [];
   const updateCalls = [];
   let storedValues = [];
@@ -129,7 +129,7 @@ test("storeSelectedSpreadsheetMeta writes key-value pair", async () => {
 });
 
 test("storeSelectedSpreadsheetMeta creates _meta sheet when missing", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const getCalls = [];
   const updateCalls = [];
   const batchCalls = [];
@@ -206,7 +206,7 @@ test("storeSelectedSpreadsheetMeta creates _meta sheet when missing", async () =
 });
 
 test("createSpreadsheet creates Drive spreadsheet", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const credentialsLog = [];
   const createCalls = [];
 

--- a/tests/google-retry.test.cjs
+++ b/tests/google-retry.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createDependencies() {
   const sleeps = [];
@@ -18,7 +18,7 @@ function createDependencies() {
 }
 
 test("executeWithRetry resolves immediately when the first attempt succeeds", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { executeWithRetry } = await jiti.import(
     "../src/server/google/retry",
   );
@@ -41,7 +41,7 @@ test("executeWithRetry resolves immediately when the first attempt succeeds", as
 });
 
 test("executeWithRetry retries on rate-limited errors using backoff", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { executeWithRetry } = await jiti.import(
     "../src/server/google/retry",
   );
@@ -72,7 +72,7 @@ test("executeWithRetry retries on rate-limited errors using backoff", async () =
 });
 
 test("executeWithRetry throws after exhausting attempts", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { executeWithRetry } = await jiti.import(
     "../src/server/google/retry",
   );

--- a/tests/helpers/create-jiti.js
+++ b/tests/helpers/create-jiti.js
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const path = require("node:path");
+const { createJiti } = require("jiti");
+
+const projectRoot = path.resolve(__dirname, "..", "..", "src");
+
+function createTestJiti(filename, options = {}) {
+  const alias = {
+    "@": projectRoot,
+    "@/": `${projectRoot}/`,
+    ...(options.alias ?? {}),
+  };
+
+  const merged = {
+    ...options,
+    alias,
+  };
+
+  return createJiti(filename, merged);
+}
+
+module.exports = { createTestJiti };

--- a/tests/manifest-events.test.cjs
+++ b/tests/manifest-events.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 test("emitManifestChange dispatches custom event", async () => {
   global.CustomEvent = class CustomEvent {
@@ -11,7 +11,7 @@ test("emitManifestChange dispatches custom event", async () => {
     }
   };
 
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { emitManifestChange, subscribeToManifestChange } = await jiti.import(
     "../src/lib/manifest-events",
   );

--- a/tests/manifest-store.test.cjs
+++ b/tests/manifest-store.test.cjs
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createMemoryStorage() {
   const data = new Map();
@@ -21,7 +21,7 @@ function createMemoryStorage() {
 }
 
 test("saveManifest stores spreadsheet identifier", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const storage = createMemoryStorage();
   const { saveManifest, loadManifest } = await jiti.import(
     "../src/lib/manifest-store",
@@ -39,7 +39,7 @@ test("saveManifest stores spreadsheet identifier", async () => {
 });
 
 test("loadManifest handles missing or invalid payloads", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const storage = createMemoryStorage();
   const { loadManifest, clearManifest } = await jiti.import(
     "../src/lib/manifest-store",

--- a/tests/meta-repository.test.cjs
+++ b/tests/meta-repository.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createSheetsStub({ values = [], throwOnGet = false } = {}) {
   const valueGetCalls = [];
@@ -44,7 +44,7 @@ function createSheetsStub({ values = [], throwOnGet = false } = {}) {
 }
 
 test("meta repository load returns key-value map", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { createMetaRepository } = await jiti.import(
     "../src/server/google/repository/meta-repository",
   );
@@ -70,7 +70,7 @@ test("meta repository load returns key-value map", async () => {
 });
 
 test("meta repository load handles missing sheet gracefully", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { createMetaRepository } = await jiti.import(
     "../src/server/google/repository/meta-repository",
   );
@@ -90,7 +90,7 @@ test("meta repository load handles missing sheet gracefully", async () => {
 });
 
 test("meta repository save writes header and entries in order", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { createMetaRepository } = await jiti.import(
     "../src/server/google/repository/meta-repository",
   );

--- a/tests/register-spreadsheet-route.test.cjs
+++ b/tests/register-spreadsheet-route.test.cjs
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function withEnv(run) {
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
@@ -24,7 +24,7 @@ function withEnv(run) {
 
 test("register route validates request payload", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createRegisterHandler } = await jiti.import(
       "../src/app/api/spreadsheet/register/route",
     );
@@ -51,7 +51,7 @@ test("register route validates request payload", async () => {
 
 test("register route maps auth errors to 401", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createRegisterHandler } = await jiti.import(
       "../src/app/api/spreadsheet/register/route",
     );
@@ -78,7 +78,7 @@ test("register route maps auth errors to 401", async () => {
 
 test("register route returns manifest on success", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createRegisterHandler } = await jiti.import(
       "../src/app/api/spreadsheet/register/route",
     );

--- a/tests/register-spreadsheet.test.cjs
+++ b/tests/register-spreadsheet.test.cjs
@@ -3,10 +3,10 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 test("registerSpreadsheetSelection requires authenticated session", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
   const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
@@ -33,7 +33,7 @@ test("registerSpreadsheetSelection requires authenticated session", async () => 
 });
 
 test("registerSpreadsheetSelection requires Google tokens", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
   const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
@@ -60,7 +60,7 @@ test("registerSpreadsheetSelection requires Google tokens", async () => {
 });
 
 test("registerSpreadsheetSelection bootstraps sheet and returns manifest", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const bootstrapCalls = [];
   let receivedTokens;
   const originalClientId = process.env.GOOGLE_CLIENT_ID;

--- a/tests/runway-projection-repository.test.cjs
+++ b/tests/runway-projection-repository.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
   const getCalls = [];
@@ -44,7 +44,7 @@ function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
 }
 
 test("runway projection repository list returns typed records", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, getCalls } = createSheetsStub({
     values: [
       [
@@ -102,7 +102,7 @@ test("runway projection repository list returns typed records", async () => {
 });
 
 test("runway projection repository list validates required fields", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub } = createSheetsStub({
     values: [
       [
@@ -132,7 +132,7 @@ test("runway projection repository list validates required fields", async () => 
 });
 
 test("runway projection repository save writes header and rows", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, updateCalls, getStoredValues } = createSheetsStub({
     values: [
       [

--- a/tests/sheet-schemas.test.cjs
+++ b/tests/sheet-schemas.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 const EXPECTED_SCHEMAS = [
   {
@@ -92,7 +92,7 @@ const EXPECTED_SCHEMAS = [
 ];
 
 test("sheet schemas export expected titles and headers", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const sheetSchemas = await jiti.import("../src/server/google/sheet-schemas");
 
   assert.ok(

--- a/tests/snapshots-repository.test.cjs
+++ b/tests/snapshots-repository.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
   const getCalls = [];
@@ -44,7 +44,7 @@ function createSheetsStub({ values = [], throwsOnGet = false } = {}) {
 }
 
 test("snapshots repository list returns typed records", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, getCalls } = createSheetsStub({
     values: [
       ["snapshot_id", "account_id", "date", "balance", "note"],
@@ -87,7 +87,7 @@ test("snapshots repository list returns typed records", async () => {
 });
 
 test("snapshots repository list validates required fields", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub } = createSheetsStub({
     values: [
       ["snapshot_id", "account_id", "date", "balance", "note"],
@@ -108,7 +108,7 @@ test("snapshots repository list validates required fields", async () => {
 });
 
 test("snapshots repository save writes header and rows", async () => {
-  const jiti = createJiti(__filename);
+  const jiti = createTestJiti(__filename);
   const { stub, updateCalls, getStoredValues } = createSheetsStub({
     values: [["snapshot_id", "account_id", "date", "balance", "note"]],
   });

--- a/tests/snapshots-route.test.cjs
+++ b/tests/snapshots-route.test.cjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { createJiti } = require("jiti");
+const { createTestJiti } = require("./helpers/create-jiti");
 
 function withEnv(run) {
   const originalClientId = process.env.GOOGLE_CLIENT_ID;
@@ -22,7 +22,7 @@ function withEnv(run) {
 
 test("snapshots route requires spreadsheetId query", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createSnapshotsHandler } = await jiti.import(
       "../src/app/api/snapshots/route",
     );
@@ -44,7 +44,7 @@ test("snapshots route requires spreadsheetId query", async () => {
 
 test("snapshots route returns data on success", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createSnapshotsHandler } = await jiti.import(
       "../src/app/api/snapshots/route",
     );
@@ -85,7 +85,7 @@ test("snapshots route returns data on success", async () => {
 
 test("snapshots create route validates payload", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createSnapshotsHandler } = await jiti.import(
       "../src/app/api/snapshots/route",
     );
@@ -112,7 +112,7 @@ test("snapshots create route validates payload", async () => {
 
 test("snapshots create route appends snapshot and returns payload", async () => {
   await withEnv(async () => {
-    const jiti = createJiti(__filename);
+    const jiti = createTestJiti(__filename);
     const { createSnapshotsHandler } = await jiti.import(
       "../src/app/api/snapshots/route",
     );


### PR DESCRIPTION
## Summary
- replace remaining relative imports in src/ with the configured @/ path alias
- provide a shared test helper so CJS tests resolve the alias when loading source files
- keep lint/tests green after the refactor

Resolves #16

## Testing
- npm run lint
- npm test