### PR TITLE
feat: add budget plan grid UI

### DIFF
--- a/docs/notes/budget-plan-grid-plan.md
+++ b/docs/notes/budget-plan-grid-plan.md
@@ -1,0 +1,65 @@
+// ABOUTME: Summarizes Budget Planner milestone scope and sequencing.
+// ABOUTME: Guides implementation of budget plan grid across API, logic, and UI.
+
+# Budget Planner Milestone Plan
+
+## Scope
+- Deliver an editable budget plan grid that displays categories versus a rolling month horizon sourced from Google Sheets.
+- Reuse `/api/categories` and `/api/budget-plan` for read/write flows, including manifest-driven spreadsheet selection and health gating.
+- Provide client-side normalization, validation, and save orchestration for monthly amounts while computing rollover balances automatically.
+- Render amounts in the base currency via `useBaseCurrency`, labeling approximated conversions when category currencies differ.
+
+## Decisions
+- Horizon: use a rolling 12-month window anchored to the current calendar month.
+- Rollover balances: compute automatically; users never edit rollover cells directly.
+- Blank months: seed default amounts from each category `monthlyBudget`.
+- Currency: keep category edits in their native currency; render converted amounts only for base currency views.
+- Visibility: show every category without filters.
+- Saves: POST the full dataset on save; skip diff batching.
+- Projection: do not trigger an immediate runway rebuild after save.
+
+## Out of Scope
+- Changing category CRUD, category monthly budget inputs, or sort order behavior.
+- Implementing projection updates, variance analytics, or future event integrations tied to budget edits.
+- Introducing new currency conversion providers or persistent user preferences beyond the existing base currency context.
+- Building drag-and-drop ordering, multi-scenario toggles, or collaborative editing features.
+
+## Current State Snapshot
+- `src/app/api/categories/route.ts` validates spreadsheet access, normalizes `CategoryRecord` data, and already powers the category manager.
+- `src/app/api/budget-plan/route.ts` exposes list/save handlers backed by `createBudgetPlanRepository`, enforcing schema headers and numeric validation.
+- Repositories in `src/server/google/repository/` handle Google Sheets I/O with retry logic and are covered by Node test suites under `tests/`.
+- The client lacks any consumer of budget plan data; `CategoryManager` demonstrates the manifest + health + base currency pattern we can mirror.
+
+## Data Flow
+1. The budget planner hook reads `spreadsheetId` from `loadManifest` once the dashboard detects a healthy spreadsheet via `useSpreadsheetHealth`.
+2. Call `/api/categories?spreadsheetId=` to obtain ordered category metadata (labels, rollover flags, monthlyBudget, currencyCode).
+3. Call `/api/budget-plan?spreadsheetId=` to retrieve existing `BudgetPlanRecord` entries.
+4. Merge categories and budget plan records into a 12-month rolling grid keyed by `categoryId` × `month/year`, seeding blank months from `monthlyBudget` defaults and computing rollovers automatically.
+5. Track user amount edits locally while recomputing derived rollovers for rows with `rolloverFlag = true`.
+6. Serialize the current grid into a full `BudgetPlanRecord[]`, generating deterministic IDs for new records to keep sheet rows stable.
+7. POST the full normalized payload to `/api/budget-plan`; on success, update the local baseline and surface confirmation.
+8. Surface errors via inline messaging and the existing spreadsheet health banner when Sheets operations fail (auth, header mismatch, etc.).
+
+## Proposed Modules and Ownership
+- **Domain transforms — `src/lib/budget-plan/grid-transforms.ts`:** Pure functions to merge category metadata with `BudgetPlanRecord` data, apply monthly defaults, compute the rolling horizon, recompute rollovers, and emit a presentational view model.
+- **Change tracking — `src/lib/budget-plan/change-tracker.ts`:** Utilities to compare original versus draft grids, validate numeric inputs, enforce computed rollover rules, and emit a full `BudgetPlanRecord[]` for save operations.
+- **API helpers — `src/lib/api/budget-plan-client.ts`:** `fetchBudgetPlan(spreadsheetId)` and `saveBudgetPlan(spreadsheetId, records)` functions wrapping `fetch`, mapping non-200 responses to actionable errors.
+- **State hook — `src/components/budget-plan/use-budget-plan-manager.ts`:** Orchestrates manifest lookup, health gating, data fetching, transforms, dirty-state tracking, and save triggers; exposes actions (`setAmount`, `setRollover`, `appendMonth`, `save`).
+- **UI components — `src/components/budget-plan/budget-plan-grid.tsx`:** Presentational table rendering month headers, category rows, rollover indicators, save/undo controls, and error states via props supplied by the state hook.
+- **Page wiring — integrate** the new manager/grid into the dashboard route, keeping other managers untouched and respecting layout conventions.
+
+## Implementation Sequence
+1. Build `grid-transforms.ts` and `change-tracker.ts`, including exhaustive unit tests to lock data shapes before UI work.
+2. Add `budget-plan-client.ts` with fetch/save wrappers plus tests covering success and failure paths.
+3. Implement `use-budget-plan-manager.ts`, substituting stub clients in tests to verify load, error, and save flows.
+4. Assemble `BudgetPlanGrid` UI components, relying on the tested hook for behavior and performing manual QA for styling/accessibility.
+5. Wire the planner into the dashboard behind existing health checks, ensuring manifest updates trigger downstream reloads.
+
+## TDD Strategy
+- `tests/budget-plan-grid-transforms.test.cjs`: Validate category sorting, default month seeding, automatic 12-month horizon building, rollover calculations, and deterministic record IDs emitted by `grid-transforms`.
+- `tests/budget-plan-change-tracker.test.cjs`: Cover validation rules (finite numbers, computed rollover propagation), dirty detection, and serialization of the full dataset back to `BudgetPlanRecord[]`.
+- `tests/budget-plan-client.test.cjs`: Stub `global.fetch` to confirm request URLs, payload shapes, and error mapping for auth and Sheets failures.
+- `tests/use-budget-plan-manager.test.cjs`: Use fake client implementations to assert loading state transitions, error propagation, dirty-state resets after saves, and append-month behavior without rendering DOM.
+
+## Open Questions + Assumptions
+- None; decisions above cover previously open items.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,10 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.5.6",
+        "jsdom": "^24.0.0",
         "tailwindcss": "^4.1.15",
+        "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5"
       },
       "engines": {
@@ -41,12 +44,172 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1205,6 +1368,34 @@
         "tailwindcss": "4.1.15"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1231,7 +1422,8 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.18.12",
@@ -1248,7 +1440,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1305,7 +1496,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.1.tgz",
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -1791,7 +1981,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1806,6 +1995,19 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -1847,6 +2049,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2029,6 +2238,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -2238,6 +2454,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2252,6 +2481,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2265,6 +2501,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -2285,6 +2542,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -2354,6 +2625,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2394,6 +2672,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2401,6 +2689,16 @@
       "devOptional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -2455,6 +2753,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -2640,7 +2951,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2807,7 +3117,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -2845,6 +3154,19 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -2852,6 +3174,19 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -3196,6 +3531,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -3566,6 +3918,33 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -3577,6 +3956,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3867,6 +4259,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4067,6 +4466,47 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -4095,15 +4535,16 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
+      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -4502,6 +4943,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4532,6 +4980,29 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4549,6 +5020,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4742,6 +5214,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/oauth": {
       "version": "0.9.15",
@@ -4968,6 +5447,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5050,7 +5542,6 @@
       "version": "10.27.2",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
       "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5092,6 +5583,19 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5115,6 +5619,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -5141,7 +5652,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5151,7 +5661,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5207,6 +5716,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -5254,6 +5770,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -5348,6 +5871,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -5746,6 +6289,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.15.tgz",
@@ -5805,7 +6355,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5825,6 +6374,35 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -5837,16 +6415,63 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/tsconfig-paths": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {
@@ -5945,7 +6570,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5977,6 +6601,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
@@ -6021,6 +6655,17 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/url-template": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
@@ -6035,6 +6680,26 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -6042,6 +6707,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -6151,6 +6863,55 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,11 @@
     "@types/node": "^22.18.12",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "jsdom": "^24.0.0",
     "eslint": "^9",
     "eslint-config-next": "15.5.6",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "tailwindcss": "^4.1.15",
     "typescript": "^5"
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { requireSession } from "@/server/auth/session";
 import { ConnectSpreadsheetCard } from "@/components/spreadsheet/connect-spreadsheet-card";
 import { BaseCurrencySelector } from "@/components/currency/base-currency-selector";
 import { CategoryManager } from "@/components/categories/category-manager";
+import { BudgetPlanManager } from "@/components/budget-plan/budget-plan-manager";
 import { AccountsManager } from "@/components/accounts/accounts-manager";
 import { SpreadsheetHealthProvider } from "@/components/spreadsheet/spreadsheet-health-context";
 import { SpreadsheetHealthPanel } from "@/components/spreadsheet/spreadsheet-health-panel";
@@ -59,6 +60,8 @@ export default async function Home() {
           <BaseCurrencySelector />
 
           <CategoryManager />
+
+          <BudgetPlanManager />
 
           <AccountsManager />
         </div>

--- a/src/components/budget-plan/budget-plan-grid.tsx
+++ b/src/components/budget-plan/budget-plan-grid.tsx
@@ -1,0 +1,198 @@
+// ABOUTME: Presents the editable budget plan grid with helper controls.
+// ABOUTME: Renders monthly inputs, conversions, and rollover indicators.
+"use client";
+
+import { useMemo } from "react";
+import type { ChangeEvent } from "react";
+
+import type {
+  BudgetPlanManagerCell,
+  BudgetPlanManagerRow,
+  BudgetPlanManagerState,
+} from "./use-budget-plan-manager";
+
+function monthLabel(month: { month: number; year: number }) {
+  const date = new Date(month.year, month.month - 1, 1);
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    year: "numeric",
+  }).format(date);
+}
+
+function formatRollover(amount: number) {
+  return amount.toLocaleString("en-US", {
+    maximumFractionDigits: 0,
+  });
+}
+
+function AmountInput({
+  manager,
+  row,
+  cell,
+  disabled,
+}: {
+  manager: BudgetPlanManagerState;
+  row: BudgetPlanManagerRow;
+  cell: BudgetPlanManagerCell;
+  disabled: boolean;
+}) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const raw = event.target.value;
+    const numeric =
+      raw.trim() === "" ? 0 : Number.parseFloat(raw.replace(/,/g, ""));
+
+    if (!Number.isFinite(numeric)) {
+      return;
+    }
+
+    manager.setAmount(row.category.categoryId, cell.monthIndex, numeric);
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      <input
+        data-cell={`${row.category.categoryId}:${cell.monthIndex}`}
+        type="number"
+        inputMode="decimal"
+        disabled={disabled}
+        value={Number.isFinite(cell.amount) ? cell.amount : 0}
+        onChange={handleChange}
+        className="w-full rounded-md border border-zinc-300/70 px-2 py-1 text-sm shadow-sm transition focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-zinc-700/60 dark:bg-zinc-900 dark:text-zinc-100"
+      />
+      {cell.baseCurrencyDisplay ? (
+        <span className="text-xs text-zinc-500 dark:text-zinc-400">
+          {cell.baseCurrencyDisplay}
+        </span>
+      ) : null}
+      {row.category.rolloverFlag && cell.rolloverBalance > 0 ? (
+        <span className="text-xs text-emerald-600 dark:text-emerald-300">
+          {`Rollover: ${formatRollover(cell.rolloverBalance)}`}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export function BudgetPlanGrid({ manager }: { manager: BudgetPlanManagerState }) {
+  const disabled = manager.isSaving || manager.status !== "ready" || !!manager.blockingMessage;
+
+  const headerLabels = useMemo(
+    () => manager.months.map((month) => monthLabel(month)),
+    [manager.months],
+  );
+
+  if (manager.status === "loading") {
+    return (
+      <section className="rounded-xl border border-zinc-200/70 bg-white/60 p-6 text-sm text-zinc-600 shadow-sm dark:border-zinc-700/60 dark:bg-zinc-900/70 dark:text-zinc-300">
+        Loading budget plan…
+      </section>
+    );
+  }
+
+  if (manager.blockingMessage) {
+    return (
+      <section className="rounded-xl border border-amber-300/70 bg-amber-50/90 p-6 text-sm text-amber-900 dark:border-amber-700/60 dark:bg-amber-900/20 dark:text-amber-100">
+        {manager.blockingMessage}
+      </section>
+    );
+  }
+
+  if (manager.status === "error") {
+    return (
+      <section className="rounded-xl border border-rose-300/70 bg-rose-50/90 p-6 text-sm text-rose-900 dark:border-rose-700/60 dark:bg-rose-900/20 dark:text-rose-100">
+        {manager.error ?? "Budget plan is temporarily unavailable. Try reloading."}
+      </section>
+    );
+  }
+
+  if (!manager.rows.length) {
+    return (
+      <section className="rounded-xl border border-dashed border-zinc-300/70 bg-zinc-50/60 p-6 text-sm text-zinc-600 shadow-sm dark:border-zinc-700/60 dark:bg-zinc-900/60 dark:text-zinc-300">
+        Connect a spreadsheet to start planning your budgets.
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex flex-col gap-4 rounded-xl border border-zinc-200/70 bg-white/60 p-6 shadow-sm dark:border-zinc-700/60 dark:bg-zinc-900/70">
+      <div className="overflow-x-auto">
+        <table className="min-w-full border-separate border-spacing-y-2 text-sm">
+          <thead>
+            <tr className="text-left text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+              <th className="px-2 py-1">Category</th>
+              {headerLabels.map((label, index) => (
+                <th key={manager.months[index]?.id ?? index} className="px-2 py-1">
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {manager.rows.map((row) => (
+              <tr
+                key={row.category.categoryId}
+                className="rounded-lg border border-transparent bg-white/60 text-sm shadow-sm dark:bg-zinc-900/60"
+              >
+                <th className="rounded-l-lg px-3 py-2 align-top text-left text-sm font-semibold text-zinc-700 dark:text-zinc-100">
+                  <div className="flex flex-col gap-1">
+                    <span>{row.category.label}</span>
+                    <span className="text-xs uppercase text-zinc-400 dark:text-zinc-500">
+                      {row.category.currencyCode}
+                    </span>
+                  </div>
+                </th>
+                {row.cells.map((cell, index) => (
+                  <td key={cell.recordId ?? `${row.category.categoryId}:${index}`} className="px-2 py-2 align-top">
+                    <AmountInput
+                      manager={manager}
+                      row={row}
+                      cell={cell}
+                      disabled={disabled}
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+          {manager.lastSavedAt ? (
+            <span>
+              Saved {new Date(manager.lastSavedAt).toLocaleTimeString()}
+            </span>
+          ) : null}
+          {manager.isSaving ? <span>Saving…</span> : null}
+          {manager.saveError ? (
+            <span className="text-rose-600 dark:text-rose-400">{manager.saveError}</span>
+          ) : null}
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            data-action="reset"
+            onClick={manager.reset}
+            disabled={!manager.isDirty || disabled}
+            className="inline-flex items-center rounded-md border border-zinc-300/70 bg-white px-3 py-2 text-xs font-semibold text-zinc-600 shadow-sm transition hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-zinc-700/60 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          >
+            Reset changes
+          </button>
+          <button
+            type="button"
+            data-action="save"
+            onClick={() => {
+              void manager.save();
+            }}
+            disabled={!manager.isDirty || manager.isSaving || manager.status !== "ready"}
+            className="inline-flex items-center rounded-md bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {manager.isSaving ? "Saving…" : "Save changes"}
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/budget-plan/budget-plan-manager.tsx
+++ b/src/components/budget-plan/budget-plan-manager.tsx
@@ -1,0 +1,41 @@
+// ABOUTME: Wraps the budget plan hook with the presentational grid.
+// ABOUTME: Provides heading and context-aware messaging for the planner.
+"use client";
+
+import { useMemo } from "react";
+
+import { BudgetPlanGrid } from "./budget-plan-grid";
+import { useBudgetPlanManager } from "./use-budget-plan-manager";
+
+export function BudgetPlanManager() {
+  const manager = useBudgetPlanManager();
+  const statusLabel = useMemo(() => {
+    if (manager.status === "loading") {
+      return "Fetching budget plan…";
+    }
+
+    if (manager.status === "blocked") {
+      return "Budget plan unavailable";
+    }
+
+    if (manager.status === "error") {
+      return "Budget plan error";
+    }
+
+    return "Budget plan";
+  }, [manager.status]);
+
+  return (
+    <section className="flex flex-col gap-4">
+      <header className="flex flex-col gap-1">
+        <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+          {statusLabel}
+        </h2>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400">
+          Allocate monthly budgets per category and keep rollover balances in sync.
+        </p>
+      </header>
+      <BudgetPlanGrid manager={manager} />
+    </section>
+  );
+}

--- a/src/components/budget-plan/use-budget-plan-manager.ts
+++ b/src/components/budget-plan/use-budget-plan-manager.ts
@@ -1,0 +1,552 @@
+// ABOUTME: Coordinates budget plan loading, editing, and saving flows.
+// ABOUTME: Exposes grid state derived from Sheets to drive the budget UI.
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from "react";
+
+import { useBaseCurrency } from "@/components/currency/base-currency-context";
+import {
+  useSpreadsheetHealth,
+} from "@/components/spreadsheet/spreadsheet-health-context";
+import {
+  filterSheetIssues,
+  shouldReloadAfterBootstrap,
+  shouldRetryAfterRecovery,
+} from "@/components/spreadsheet/spreadsheet-health-helpers";
+import {
+  loadManifest,
+  manifestStorageKey,
+  type ManifestRecord,
+} from "@/lib/manifest-store";
+import { subscribeToManifestChange } from "@/lib/manifest-events";
+import { debugLog } from "@/lib/debug-log";
+import {
+  fetchBudgetPlan,
+  saveBudgetPlan,
+} from "@/lib/api/budget-plan-client";
+import {
+  buildBudgetPlanGrid,
+  type BudgetPlanGrid,
+  type BudgetPlanMonth,
+  type BudgetPlanRow,
+} from "@/lib/budget-plan/grid-transforms";
+import {
+  applyAmountChange,
+  createBudgetPlanDraft,
+  isBudgetPlanDraftDirty,
+  serializeBudgetPlanDraft,
+  type BudgetPlanDraft,
+} from "@/lib/budget-plan/change-tracker";
+import type { CategoryRecord } from "@/server/google/repository/categories-repository";
+
+const BUDGET_PLAN_SHEET_ID = "budget_plan";
+
+type LoadState = "idle" | "loading" | "ready" | "error";
+
+export type BudgetPlanManagerStatus =
+  | "idle"
+  | "loading"
+  | "ready"
+  | "blocked"
+  | "error";
+
+export interface BudgetPlanManagerCell {
+  recordId: string;
+  monthIndex: number;
+  month: number;
+  year: number;
+  amount: number;
+  rolloverBalance: number;
+  baseCurrencyDisplay: string | null;
+  isGenerated: boolean;
+}
+
+export interface BudgetPlanManagerRow {
+  category: BudgetPlanRow["category"];
+  cells: BudgetPlanManagerCell[];
+}
+
+export interface BudgetPlanManagerState {
+  status: BudgetPlanManagerStatus;
+  blockingMessage: string | null;
+  error: string | null;
+  saveError: string | null;
+  isSaving: boolean;
+  isDirty: boolean;
+  months: BudgetPlanMonth[];
+  rows: BudgetPlanManagerRow[];
+  lastSavedAt: string | null;
+  setAmount: (categoryId: string, monthIndex: number, amount: number) => void;
+  reset: () => void;
+  save: () => Promise<void>;
+}
+
+interface UseBudgetPlanManagerOptions {
+  startDate?: Date;
+}
+
+interface FetchBudgetPlanResult {
+  grid: BudgetPlanGrid;
+  draft: BudgetPlanDraft;
+  categories: CategoryRecord[];
+}
+
+function normalizeCategoryRecord(entry: Record<string, unknown>): CategoryRecord {
+  const categoryId = String(entry.categoryId ?? "").trim();
+  const label = String(entry.label ?? "").trim();
+  const color = String(entry.color ?? "").trim() || "#999999";
+  const rolloverFlag = Boolean(entry.rolloverFlag);
+  const sortOrder =
+    typeof entry.sortOrder === "number" && Number.isFinite(entry.sortOrder)
+      ? entry.sortOrder
+      : 0;
+  const monthlyBudgetRaw =
+    typeof entry.monthlyBudget === "number" && Number.isFinite(entry.monthlyBudget)
+      ? entry.monthlyBudget
+      : 0;
+  const currencyCode = String(entry.currencyCode ?? "").trim().toUpperCase() || "USD";
+
+  return {
+    categoryId,
+    label,
+    color,
+    rolloverFlag,
+    sortOrder,
+    monthlyBudget: monthlyBudgetRaw,
+    currencyCode,
+  };
+}
+
+async function fetchCategories(spreadsheetId: string): Promise<CategoryRecord[]> {
+  const response = await fetch(
+    `/api/categories?spreadsheetId=${encodeURIComponent(spreadsheetId)}`,
+  );
+  const payload = (await response.json().catch(() => ({}))) as {
+    categories?: unknown;
+    error?: unknown;
+  };
+
+  if (!response.ok) {
+    const message =
+      typeof payload?.error === "string" && payload.error.trim()
+        ? payload.error.trim()
+        : "Failed to load categories";
+    throw new Error(message);
+  }
+
+  const source = Array.isArray(payload?.categories) ? payload.categories : [];
+  const normalized = source
+    .filter((item): item is Record<string, unknown> => !!item && typeof item === "object")
+    .map((item) => normalizeCategoryRecord(item as Record<string, unknown>))
+    .sort((left, right) => {
+      if (left.sortOrder !== right.sortOrder) {
+        return left.sortOrder - right.sortOrder;
+      }
+
+      return left.label.localeCompare(right.label);
+    });
+
+  return normalized;
+}
+
+function cloneDraft(draft: BudgetPlanDraft | null): BudgetPlanDraft | null {
+  if (!draft) {
+    return null;
+  }
+
+  return {
+    months: draft.months.map((month) => ({ ...month })),
+    rows: draft.rows.map((row) => ({
+      category: { ...row.category },
+      cells: row.cells.map((cell) => ({ ...cell })),
+    })),
+  };
+}
+
+function createViewRows(
+  draft: BudgetPlanDraft | null,
+  baseCurrency: string,
+  convertAmount: (amount: number, fromCurrency: string) => number | null,
+  formatAmount: (amount: number, isApproximation?: boolean) => string,
+): BudgetPlanManagerRow[] {
+  if (!draft) {
+    return [];
+  }
+
+  const rows: BudgetPlanManagerRow[] = [];
+
+  for (const row of draft.rows) {
+    const cells: BudgetPlanManagerCell[] = [];
+    const categoryCurrency = row.category.currencyCode || baseCurrency;
+    const approximate = categoryCurrency.toUpperCase() !== baseCurrency.toUpperCase();
+
+    for (let index = 0; index < row.cells.length; index += 1) {
+      const cell = row.cells[index];
+      const converted = convertAmount(cell.amount, categoryCurrency);
+
+      cells.push({
+        recordId: cell.recordId,
+        monthIndex: index,
+        month: cell.month,
+        year: cell.year,
+        amount: cell.amount,
+        rolloverBalance: cell.rolloverBalance,
+        baseCurrencyDisplay:
+          converted == null ? null : formatAmount(converted, approximate),
+        isGenerated: cell.isGenerated,
+      });
+    }
+
+    rows.push({
+      category: { ...row.category },
+      cells,
+    });
+  }
+
+  return rows;
+}
+
+function useManifestState(): ManifestRecord | null {
+  const [manifest, setManifest] = useState<ManifestRecord | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const updateManifest = () => {
+      const stored = loadManifest(window.localStorage);
+      setManifest(stored);
+    };
+
+    updateManifest();
+    void debugLog("Budget plan manager loaded manifest", loadManifest(window.localStorage));
+
+    const unsubscribe = subscribeToManifestChange((record) => {
+      setManifest(record as ManifestRecord | null);
+    });
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === manifestStorageKey()) {
+        updateManifest();
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      unsubscribe();
+    };
+  }, []);
+
+  return manifest;
+}
+
+function usePrevious<T>(value: T): MutableRefObject<T | undefined> {
+  const ref = useRef<T | undefined>(undefined);
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref;
+}
+
+async function loadBudgetPlanData({
+  spreadsheetId,
+  startDate,
+}: {
+  spreadsheetId: string;
+  startDate: Date | undefined;
+}): Promise<FetchBudgetPlanResult> {
+  const categories = await fetchCategories(spreadsheetId);
+  const budgetPlan = await fetchBudgetPlan(spreadsheetId);
+
+  const grid = buildBudgetPlanGrid({
+    categories,
+    budgetPlan,
+    startDate,
+  });
+
+  const draft = createBudgetPlanDraft(grid);
+
+  return {
+    grid,
+    draft,
+    categories,
+  };
+}
+
+export function useBudgetPlanManager(
+  options: UseBudgetPlanManagerOptions = {},
+): BudgetPlanManagerState {
+  const manifest = useManifestState();
+  const spreadsheetId = manifest?.spreadsheetId ?? null;
+
+  const { diagnostics } = useSpreadsheetHealth();
+  const {
+    baseCurrency,
+    convertAmount,
+    formatAmount,
+  } = useBaseCurrency();
+
+  const budgetHealth = useMemo(
+    () =>
+      filterSheetIssues(diagnostics, {
+        sheetId: BUDGET_PLAN_SHEET_ID,
+        fallbackTitle: "Budget plan",
+      }),
+    [diagnostics],
+  );
+
+  const [loadState, setLoadState] = useState<LoadState>("idle");
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(null);
+  const [baselineGrid, setBaselineGrid] = useState<BudgetPlanGrid | null>(null);
+  const [baselineCategories, setBaselineCategories] = useState<CategoryRecord[]>([]);
+  const [draft, setDraft] = useState<BudgetPlanDraft | null>(null);
+
+  const startDateInput = options.startDate ?? null;
+  const startDate = useMemo(
+    () => (startDateInput ? new Date(startDateInput) : undefined),
+    [startDateInput],
+  );
+
+  const manifestStoredAt = manifest?.storedAt ?? null;
+  const previousManifestStoredAtRef = usePrevious<number | null>(manifestStoredAt);
+  const previousHealthBlockedRef = usePrevious<boolean>(budgetHealth.hasErrors);
+
+  const loadBudgetPlan = useCallback(
+    async (id: string) => {
+      setLoadState("loading");
+      setLoadError(null);
+      setSaveError(null);
+      setLastSavedAt(null);
+
+      try {
+        const { grid, draft: loadedDraft, categories } =
+          await loadBudgetPlanData({
+            spreadsheetId: id,
+            startDate,
+          });
+
+        setBaselineGrid(grid);
+        setBaselineCategories(categories);
+        setDraft(cloneDraft(loadedDraft));
+        setLoadState("ready");
+        void debugLog("Budget plan loaded", {
+          categories: categories.length,
+          records: grid.rows.reduce((total, row) => total + row.cells.length, 0),
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Failed to load budget plan";
+        setLoadState("error");
+        setLoadError(message);
+        setBaselineGrid(null);
+        setBaselineCategories([]);
+        setDraft(null);
+        void debugLog("Budget plan load error", { message });
+      }
+    },
+    [startDate],
+  );
+
+  useEffect(() => {
+    if (!spreadsheetId) {
+      setLoadState("idle");
+      setLoadError(null);
+      setSaveError(null);
+      setLastSavedAt(null);
+      setBaselineGrid(null);
+      setBaselineCategories([]);
+      setDraft(null);
+      return;
+    }
+
+    if (budgetHealth.hasErrors) {
+      return;
+    }
+
+    void loadBudgetPlan(spreadsheetId);
+  }, [spreadsheetId, budgetHealth.hasErrors, loadBudgetPlan, startDate]);
+
+  useEffect(() => {
+    if (!spreadsheetId) {
+      return;
+    }
+
+    const previousBlocked = previousHealthBlockedRef.current ?? false;
+
+    if (shouldRetryAfterRecovery(previousBlocked, budgetHealth.hasErrors)) {
+      void loadBudgetPlan(spreadsheetId);
+    }
+  }, [
+    budgetHealth.hasErrors,
+    loadBudgetPlan,
+    previousHealthBlockedRef,
+    spreadsheetId,
+  ]);
+
+  useEffect(() => {
+    if (!spreadsheetId) {
+      return;
+    }
+
+    const previousStoredAt = previousManifestStoredAtRef.current ?? null;
+
+    if (shouldReloadAfterBootstrap(previousStoredAt, manifestStoredAt)) {
+      void loadBudgetPlan(spreadsheetId);
+    }
+  }, [
+    loadBudgetPlan,
+    manifestStoredAt,
+    previousManifestStoredAtRef,
+    spreadsheetId,
+  ]);
+
+  const months = draft?.months ?? baselineGrid?.months ?? [];
+
+  const rows = useMemo(
+    () =>
+      createViewRows(draft, baseCurrency, convertAmount, formatAmount),
+    [draft, baseCurrency, convertAmount, formatAmount],
+  );
+
+  const isDirty = draft ? isBudgetPlanDraftDirty(draft) : false;
+  const blockingMessage = budgetHealth.hasErrors
+    ? `Spreadsheet health flagged issues with the ${budgetHealth.sheetTitle} tab. Fix the problems above, then reload.`
+    : null;
+
+  const status: BudgetPlanManagerStatus = (() => {
+    if (!spreadsheetId) {
+      return "idle";
+    }
+
+    if (budgetHealth.hasErrors) {
+      return "blocked";
+    }
+
+    if (loadState === "error") {
+      return "error";
+    }
+
+    if (loadState === "loading") {
+      return "loading";
+    }
+
+    if (draft) {
+      return "ready";
+    }
+
+    return "idle";
+  })();
+
+  const setAmount = useCallback(
+    (categoryId: string, monthIndex: number, amount: number) => {
+      setDraft((current) => {
+        if (!current) {
+          return current;
+        }
+
+        try {
+          return applyAmountChange(current, { categoryId, monthIndex, amount });
+        } catch (error) {
+          void debugLog("Budget plan amount change error", {
+            message: error instanceof Error ? error.message : String(error),
+          });
+          return current;
+        }
+      });
+    },
+    [],
+  );
+
+  const reset = useCallback(() => {
+    if (!baselineGrid) {
+      return;
+    }
+
+    const nextDraft = createBudgetPlanDraft(baselineGrid);
+    setDraft(cloneDraft(nextDraft));
+    setSaveError(null);
+    setLastSavedAt(null);
+  }, [baselineGrid]);
+
+  const save = useCallback(async () => {
+    if (
+      !spreadsheetId ||
+      !draft ||
+      !baselineGrid ||
+      baselineCategories.length === 0 ||
+      isSaving
+    ) {
+      return;
+    }
+
+    setIsSaving(true);
+    setSaveError(null);
+
+    const payload = serializeBudgetPlanDraft(draft);
+
+    try {
+      const updatedRecords = await saveBudgetPlan(spreadsheetId, payload);
+      const nextGrid = buildBudgetPlanGrid({
+        categories: baselineCategories,
+        budgetPlan: updatedRecords.length > 0 ? updatedRecords : payload,
+        startDate,
+      });
+      const nextDraft = createBudgetPlanDraft(nextGrid);
+      setBaselineGrid(nextGrid);
+      setDraft(cloneDraft(nextDraft));
+      const savedAt = new Date().toISOString();
+      setLastSavedAt(savedAt);
+      void debugLog("Budget plan saved", {
+        records: updatedRecords.length,
+        savedAt,
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to save budget plan";
+      setSaveError(message);
+      void debugLog("Budget plan save error", { message });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    baselineCategories,
+    baselineGrid,
+    draft,
+    isSaving,
+    spreadsheetId,
+    startDate,
+  ]);
+
+  const error =
+    status === "error"
+      ? loadError ?? "Budget plan is temporarily unavailable."
+      : null;
+
+  return {
+    status,
+    blockingMessage,
+    error,
+    saveError,
+    isSaving,
+    isDirty,
+    months,
+    rows,
+    lastSavedAt,
+    setAmount,
+    reset,
+    save,
+  };
+}

--- a/src/lib/api/budget-plan-client.ts
+++ b/src/lib/api/budget-plan-client.ts
@@ -1,0 +1,72 @@
+// ABOUTME: Wraps budget plan API calls for client-side usage.
+// ABOUTME: Normalizes responses and raises typed errors for failures.
+import type { BudgetPlanRecord } from "@/server/google/repository/budget-plan-repository";
+
+const FETCH_ERROR_MESSAGE = "Failed to fetch budget plan";
+const SAVE_ERROR_MESSAGE = "Failed to save budget plan";
+
+export class BudgetPlanClientError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "BudgetPlanClientError";
+    this.status = status;
+  }
+}
+
+function ensureSpreadsheetId(value: string) {
+  if (!value || !value.trim()) {
+    throw new Error("Missing spreadsheetId");
+  }
+
+  return value.trim();
+}
+
+async function parseBudgetPlanPayload(response: Response, defaultMessage: string) {
+  const payload = (await response.json().catch(() => ({}))) as {
+    budgetPlan?: unknown;
+    error?: unknown;
+  };
+
+  if (!response.ok) {
+    const message =
+      typeof payload?.error === "string" && payload.error.trim()
+        ? payload.error.trim()
+        : defaultMessage;
+
+    throw new BudgetPlanClientError(response.status, message);
+  }
+
+  const records = Array.isArray(payload?.budgetPlan) ? payload.budgetPlan : [];
+
+  return records as BudgetPlanRecord[];
+}
+
+export async function fetchBudgetPlan(spreadsheetId: string): Promise<BudgetPlanRecord[]> {
+  const normalizedId = ensureSpreadsheetId(spreadsheetId);
+  const response = await fetch(
+    `/api/budget-plan?spreadsheetId=${encodeURIComponent(normalizedId)}`,
+  );
+
+  return parseBudgetPlanPayload(response, FETCH_ERROR_MESSAGE);
+}
+
+export async function saveBudgetPlan(
+  spreadsheetId: string,
+  budgetPlan: BudgetPlanRecord[],
+): Promise<BudgetPlanRecord[]> {
+  const normalizedId = ensureSpreadsheetId(spreadsheetId);
+  const response = await fetch(
+    `/api/budget-plan?spreadsheetId=${encodeURIComponent(normalizedId)}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ budgetPlan }),
+    },
+  );
+
+  return parseBudgetPlanPayload(response, SAVE_ERROR_MESSAGE);
+}

--- a/src/lib/budget-plan/change-tracker.ts
+++ b/src/lib/budget-plan/change-tracker.ts
@@ -1,0 +1,171 @@
+// ABOUTME: Manages draft budget plan state derived from grid transforms.
+// ABOUTME: Validates edits, tracks dirty state, and serializes records for saves.
+import type { BudgetPlanRecord } from "@/server/google/repository/budget-plan-repository";
+
+import type {
+  BudgetPlanCell,
+  BudgetPlanGrid,
+  BudgetPlanMonth,
+  BudgetPlanRow,
+} from "./grid-transforms";
+
+export interface BudgetPlanDraftCell extends BudgetPlanCell {
+  baselineAmount: number;
+}
+
+export interface BudgetPlanDraftRow {
+  category: BudgetPlanRow["category"];
+  cells: BudgetPlanDraftCell[];
+}
+
+export interface BudgetPlanDraft {
+  months: BudgetPlanMonth[];
+  rows: BudgetPlanDraftRow[];
+}
+
+interface ApplyAmountChangeOptions {
+  categoryId: string;
+  monthIndex: number;
+  amount: number;
+}
+
+function cloneMonths(months: BudgetPlanMonth[]): BudgetPlanMonth[] {
+  return months.map((month) => ({ ...month }));
+}
+
+function cloneCells(cells: BudgetPlanCell[]): BudgetPlanDraftCell[] {
+  return cells.map((cell) => ({
+    ...cell,
+    baselineAmount: cell.amount,
+  }));
+}
+
+export function createBudgetPlanDraft(grid: BudgetPlanGrid): BudgetPlanDraft {
+  const months = cloneMonths(grid.months);
+  const rows = grid.rows.map((row) => ({
+    category: { ...row.category },
+    cells: cloneCells(row.cells),
+  }));
+
+  return { months, rows };
+}
+
+function recomputeRowRollovers(row: BudgetPlanDraftRow) {
+  const monthlyBudget = Number.isFinite(row.category.monthlyBudget)
+    ? row.category.monthlyBudget
+    : 0;
+
+  if (!row.category.rolloverFlag) {
+    return row.cells.map((cell) => ({
+      ...cell,
+      rolloverBalance: 0,
+    }));
+  }
+
+  let running = 0;
+
+  return row.cells.map((cell) => {
+    const openingBalance = Math.max(0, running);
+    const diff = monthlyBudget - cell.amount;
+    const closingBalance = openingBalance + diff;
+    running = Math.max(0, closingBalance);
+
+    return {
+      ...cell,
+      rolloverBalance: openingBalance,
+    };
+  });
+}
+
+function cloneRow(row: BudgetPlanDraftRow, updatedCells: BudgetPlanDraftCell[]) {
+  return {
+    category: { ...row.category },
+    cells: updatedCells,
+  };
+}
+
+export function applyAmountChange(
+  draft: BudgetPlanDraft,
+  { categoryId, monthIndex, amount }: ApplyAmountChangeOptions,
+): BudgetPlanDraft {
+  if (!Number.isFinite(amount)) {
+    throw new Error("Amount must be a finite number");
+  }
+
+  const rowIndex = draft.rows.findIndex(
+    (row) => row.category.categoryId === categoryId,
+  );
+
+  if (rowIndex === -1) {
+    throw new Error(`Category ${categoryId} not found in draft`);
+  }
+
+  const targetRow = draft.rows[rowIndex];
+
+  if (monthIndex < 0 || monthIndex >= targetRow.cells.length) {
+    throw new Error(`Month index ${monthIndex} is out of range`);
+  }
+
+  const nextCells = targetRow.cells.map((cell, index) => {
+    if (index !== monthIndex) {
+      return { ...cell };
+    }
+
+    return {
+      ...cell,
+      amount,
+    };
+  });
+
+  const recomputedCells = recomputeRowRollovers({
+    category: targetRow.category,
+    cells: nextCells,
+  });
+
+  const rows = draft.rows.map((row, index) => {
+    if (index !== rowIndex) {
+      return {
+        category: { ...row.category },
+        cells: row.cells.map((cell) => ({ ...cell })),
+      };
+    }
+
+    return cloneRow(targetRow, recomputedCells);
+  });
+
+  return {
+    months: cloneMonths(draft.months),
+    rows,
+  };
+}
+
+export function isBudgetPlanDraftDirty(draft: BudgetPlanDraft) {
+  for (const row of draft.rows) {
+    for (const cell of row.cells) {
+      if (cell.amount !== cell.baselineAmount) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export function serializeBudgetPlanDraft(draft: BudgetPlanDraft): BudgetPlanRecord[] {
+  const records: BudgetPlanRecord[] = [];
+
+  for (const row of draft.rows) {
+    for (const cell of row.cells) {
+      records.push({
+        recordId: cell.recordId,
+        categoryId: cell.categoryId,
+        month: cell.month,
+        year: cell.year,
+        amount: cell.amount,
+        rolloverBalance: cell.rolloverBalance,
+      });
+    }
+  }
+
+  return records;
+}

--- a/src/lib/budget-plan/grid-transforms.ts
+++ b/src/lib/budget-plan/grid-transforms.ts
@@ -1,0 +1,193 @@
+// ABOUTME: Builds normalized budget plan grid rows for UI consumption.
+// ABOUTME: Computes rolling months, seeded amounts, and rollover balances.
+import type { CategoryRecord } from "@/server/google/repository/categories-repository";
+import type { BudgetPlanRecord } from "@/server/google/repository/budget-plan-repository";
+
+const DEFAULT_HORIZON_MONTHS = 12;
+
+export interface BudgetPlanMonth {
+  id: string;
+  month: number;
+  year: number;
+  index: number;
+}
+
+export interface BudgetPlanCategorySummary {
+  categoryId: string;
+  label: string;
+  color: string;
+  rolloverFlag: boolean;
+  monthlyBudget: number;
+  currencyCode: string;
+}
+
+export interface BudgetPlanCell {
+  recordId: string;
+  categoryId: string;
+  month: number;
+  year: number;
+  amount: number;
+  rolloverBalance: number;
+  isGenerated: boolean;
+}
+
+export interface BudgetPlanRow {
+  category: BudgetPlanCategorySummary;
+  cells: BudgetPlanCell[];
+}
+
+export interface BudgetPlanGrid {
+  months: BudgetPlanMonth[];
+  rows: BudgetPlanRow[];
+}
+
+export interface BuildBudgetPlanGridOptions {
+  categories: CategoryRecord[];
+  budgetPlan: BudgetPlanRecord[];
+  startDate?: Date;
+  horizon?: number;
+}
+
+interface BudgetPlanRecordKeyParts {
+  categoryId: string;
+  year: number;
+  month: number;
+}
+
+function padMonth(month: number) {
+  return String(month).padStart(2, "0");
+}
+
+function makeRecordKey({ categoryId, year, month }: BudgetPlanRecordKeyParts) {
+  return `${categoryId}:${year}-${padMonth(month)}`;
+}
+
+export function generateBudgetPlanRecordId({
+  categoryId,
+  year,
+  month,
+}: BudgetPlanRecordKeyParts) {
+  return `budget_${categoryId}_${year}-${padMonth(month)}`;
+}
+
+function normalizeStartDate(date: Date | undefined) {
+  const reference = date ? new Date(date) : new Date();
+  return new Date(reference.getFullYear(), reference.getMonth(), 1);
+}
+
+function buildMonths(startDate: Date, horizon: number): BudgetPlanMonth[] {
+  const months: BudgetPlanMonth[] = [];
+
+  for (let index = 0; index < horizon; index += 1) {
+    const cursor = new Date(startDate.getFullYear(), startDate.getMonth() + index, 1);
+    const monthNumber = cursor.getMonth() + 1;
+    const year = cursor.getFullYear();
+
+    months.push({
+      id: `${year}-${padMonth(monthNumber)}`,
+      month: monthNumber,
+      year,
+      index,
+    });
+  }
+
+  return months;
+}
+
+function normalizeMonthlyBudget(value: number) {
+  return Number.isFinite(value) ? value : 0;
+}
+
+function sortCategories(left: CategoryRecord, right: CategoryRecord) {
+  if (left.sortOrder !== right.sortOrder) {
+    return left.sortOrder - right.sortOrder;
+  }
+
+  return left.label.localeCompare(right.label);
+}
+
+export function buildBudgetPlanGrid({
+  categories,
+  budgetPlan,
+  startDate: rawStartDate,
+  horizon = DEFAULT_HORIZON_MONTHS,
+}: BuildBudgetPlanGridOptions): BudgetPlanGrid {
+  const startDate = normalizeStartDate(rawStartDate);
+  const months = buildMonths(startDate, horizon);
+
+  const recordLookup = new Map<string, BudgetPlanRecord>();
+
+  for (const record of budgetPlan) {
+    const key = makeRecordKey({
+      categoryId: record.categoryId,
+      year: record.year,
+      month: record.month,
+    });
+
+    recordLookup.set(key, record);
+  }
+
+  const sortedCategories = [...categories].sort(sortCategories);
+  const rows: BudgetPlanRow[] = [];
+
+  for (const category of sortedCategories) {
+    const monthlyBudget = normalizeMonthlyBudget(category.monthlyBudget);
+    const summary: BudgetPlanCategorySummary = {
+      categoryId: category.categoryId,
+      label: category.label,
+      color: category.color,
+      rolloverFlag: Boolean(category.rolloverFlag),
+      monthlyBudget,
+      currencyCode: category.currencyCode,
+    };
+
+    const cells: BudgetPlanCell[] = [];
+    let runningRollover = 0;
+
+    for (const month of months) {
+      const key = makeRecordKey({
+        categoryId: category.categoryId,
+        year: month.year,
+        month: month.month,
+      });
+
+      const record = recordLookup.get(key);
+      const amount = record?.amount ?? monthlyBudget;
+      const isGenerated = !record;
+      const recordId =
+        record?.recordId ??
+        generateBudgetPlanRecordId({
+          categoryId: category.categoryId,
+          year: month.year,
+          month: month.month,
+        });
+
+      let rolloverBalance = 0;
+
+      if (category.rolloverFlag) {
+        const openingBalance = Math.max(0, runningRollover);
+        rolloverBalance = openingBalance;
+        const diff = monthlyBudget - amount;
+        const closingBalance = openingBalance + diff;
+        runningRollover = Math.max(0, closingBalance);
+      }
+
+      cells.push({
+        recordId,
+        categoryId: category.categoryId,
+        month: month.month,
+        year: month.year,
+        amount,
+        rolloverBalance,
+        isGenerated,
+      });
+    }
+
+    rows.push({
+      category: summary,
+      cells,
+    });
+  }
+
+  return { months, rows };
+}

--- a/tests/budget-plan-change-tracker.test.cjs
+++ b/tests/budget-plan-change-tracker.test.cjs
@@ -1,0 +1,189 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { createTestJiti } = require("./helpers/create-jiti");
+
+async function loadModules() {
+  const jiti = createTestJiti(__filename);
+  const gridTransforms = await jiti.import("../src/lib/budget-plan/grid-transforms");
+  const changeTracker = await jiti.import("../src/lib/budget-plan/change-tracker");
+
+  return { gridTransforms, changeTracker };
+}
+
+function createCategory(overrides = {}) {
+  return {
+    categoryId: "cat-roll",
+    label: "Category",
+    color: "#123456",
+    rolloverFlag: true,
+    sortOrder: 1,
+    monthlyBudget: 200,
+    currencyCode: "USD",
+    ...overrides,
+  };
+}
+
+test("createBudgetPlanDraft clones baseline grid data", async () => {
+  const { gridTransforms, changeTracker } = await loadModules();
+  const { buildBudgetPlanGrid } = gridTransforms;
+  const { createBudgetPlanDraft } = changeTracker;
+
+  const grid = buildBudgetPlanGrid({
+    categories: [createCategory()],
+    budgetPlan: [],
+    startDate: new Date("2024-01-01"),
+  });
+
+  const draft = createBudgetPlanDraft(grid);
+
+  assert.notEqual(draft.rows[0], grid.rows[0]);
+  assert.notEqual(draft.rows[0].cells[0], grid.rows[0].cells[0]);
+  assert.equal(draft.rows[0].cells[0].amount, grid.rows[0].cells[0].amount);
+});
+
+test("applyAmountChange validates numeric input", async () => {
+  const { gridTransforms, changeTracker } = await loadModules();
+  const { buildBudgetPlanGrid } = gridTransforms;
+  const { createBudgetPlanDraft, applyAmountChange } = changeTracker;
+
+  const grid = buildBudgetPlanGrid({
+    categories: [createCategory()],
+    budgetPlan: [],
+    startDate: new Date("2024-01-01"),
+  });
+
+  const draft = createBudgetPlanDraft(grid);
+
+  assert.throws(() =>
+    applyAmountChange(draft, { categoryId: "cat-roll", monthIndex: 0, amount: NaN }),
+  );
+});
+
+test("applyAmountChange updates amounts and recomputes rollover balances", async () => {
+  const { gridTransforms, changeTracker } = await loadModules();
+  const { buildBudgetPlanGrid } = gridTransforms;
+  const { createBudgetPlanDraft, applyAmountChange } = changeTracker;
+
+  const grid = buildBudgetPlanGrid({
+    categories: [createCategory()],
+    budgetPlan: [
+      {
+        recordId: "rec-jan",
+        categoryId: "cat-roll",
+        month: 1,
+        year: 2024,
+        amount: 150,
+        rolloverBalance: 0,
+      },
+      {
+        recordId: "rec-feb",
+        categoryId: "cat-roll",
+        month: 2,
+        year: 2024,
+        amount: 200,
+        rolloverBalance: 0,
+      },
+    ],
+    startDate: new Date("2024-01-01"),
+  });
+
+  const original = createBudgetPlanDraft(grid);
+  const updated = applyAmountChange(original, {
+    categoryId: "cat-roll",
+    monthIndex: 0,
+    amount: 100,
+  });
+
+  const row = updated.rows[0];
+
+  assert.equal(row.cells[0].amount, 100);
+  assert.deepEqual(
+    row.cells.slice(0, 4).map((cell) => cell.rolloverBalance),
+    [0, 100, 100, 100],
+  );
+});
+
+test("isBudgetPlanDraftDirty flags changes and resets after revert", async () => {
+  const { gridTransforms, changeTracker } = await loadModules();
+  const { buildBudgetPlanGrid } = gridTransforms;
+  const { createBudgetPlanDraft, applyAmountChange, isBudgetPlanDraftDirty } =
+    changeTracker;
+
+  const grid = buildBudgetPlanGrid({
+    categories: [createCategory({ monthlyBudget: 150 })],
+    budgetPlan: [],
+    startDate: new Date("2024-01-01"),
+  });
+
+  const draft = createBudgetPlanDraft(grid);
+  assert.equal(isBudgetPlanDraftDirty(draft), false);
+
+  const changed = applyAmountChange(draft, {
+    categoryId: "cat-roll",
+    monthIndex: 1,
+    amount: 120,
+  });
+
+  assert.equal(isBudgetPlanDraftDirty(changed), true);
+
+  const reverted = applyAmountChange(changed, {
+    categoryId: "cat-roll",
+    monthIndex: 1,
+    amount: 150,
+  });
+
+  assert.equal(isBudgetPlanDraftDirty(reverted), false);
+});
+
+test("serializeBudgetPlanDraft emits full record list", async () => {
+  const { gridTransforms, changeTracker } = await loadModules();
+  const { buildBudgetPlanGrid } = gridTransforms;
+  const {
+    createBudgetPlanDraft,
+    applyAmountChange,
+    serializeBudgetPlanDraft,
+  } = changeTracker;
+
+  const grid = buildBudgetPlanGrid({
+    categories: [createCategory({ categoryId: "cat-serial", monthlyBudget: 300 })],
+    budgetPlan: [
+      {
+        recordId: "rec-start",
+        categoryId: "cat-serial",
+        month: 3,
+        year: 2024,
+        amount: 320,
+        rolloverBalance: 0,
+      },
+    ],
+    startDate: new Date("2024-03-01"),
+  });
+
+  const draft = createBudgetPlanDraft(grid);
+  const changed = applyAmountChange(draft, {
+    categoryId: "cat-serial",
+    monthIndex: 2,
+    amount: 250,
+  });
+
+  const records = serializeBudgetPlanDraft(changed);
+
+  assert.equal(records.length, 12);
+
+  const first = records[0];
+  assert.equal(first.categoryId, "cat-serial");
+  assert.equal(first.month, 3);
+  assert.equal(first.year, 2024);
+  assert.equal(first.amount, 320);
+
+  const third = records[2];
+  assert.equal(third.amount, 250);
+  assert.equal(third.rolloverBalance, 0);
+
+  const fourth = records[3];
+  assert.equal(fourth.rolloverBalance, 50);
+
+  const last = records[records.length - 1];
+  assert.equal(last.recordId.startsWith("budget_cat-serial_"), true);
+});

--- a/tests/budget-plan-grid-transforms.test.cjs
+++ b/tests/budget-plan-grid-transforms.test.cjs
@@ -1,0 +1,190 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { createTestJiti } = require("./helpers/create-jiti");
+
+async function loadGridTransforms() {
+  const jiti = createTestJiti(__filename);
+  return jiti.import("../src/lib/budget-plan/grid-transforms");
+}
+
+function createCategory(overrides = {}) {
+  return {
+    categoryId: "cat-1",
+    label: "Category 1",
+    color: "#000000",
+    rolloverFlag: false,
+    sortOrder: 1,
+    monthlyBudget: 0,
+    currencyCode: "USD",
+    ...overrides,
+  };
+}
+
+test("buildBudgetPlanGrid sorts categories by sortOrder", async () => {
+  const { buildBudgetPlanGrid } = await loadGridTransforms();
+
+  const categories = [
+    createCategory({ categoryId: "cat-b", label: "B", sortOrder: 20 }),
+    createCategory({ categoryId: "cat-a", label: "A", sortOrder: 10 }),
+  ];
+
+  const grid = buildBudgetPlanGrid({
+    categories,
+    budgetPlan: [],
+    startDate: new Date("2024-01-10"),
+  });
+
+  assert.deepEqual(
+    grid.rows.map((row) => row.category.categoryId),
+    ["cat-a", "cat-b"],
+  );
+});
+
+test("buildBudgetPlanGrid creates 12 month rolling horizon", async () => {
+  const { buildBudgetPlanGrid } = await loadGridTransforms();
+
+  const grid = buildBudgetPlanGrid({
+    categories: [createCategory()],
+    budgetPlan: [],
+    startDate: new Date("2024-05-15"),
+  });
+
+  assert.equal(grid.months.length, 12);
+  assert.deepEqual(
+    grid.months.map((month) => month.id),
+    [
+      "2024-05",
+      "2024-06",
+      "2024-07",
+      "2024-08",
+      "2024-09",
+      "2024-10",
+      "2024-11",
+      "2024-12",
+      "2025-01",
+      "2025-02",
+      "2025-03",
+      "2025-04",
+    ],
+  );
+});
+
+test("buildBudgetPlanGrid seeds blank months from monthlyBudget", async () => {
+  const { buildBudgetPlanGrid } = await loadGridTransforms();
+
+  const grid = buildBudgetPlanGrid({
+    categories: [createCategory({ monthlyBudget: 250 })],
+    budgetPlan: [],
+    startDate: new Date("2024-02-01"),
+  });
+
+  const row = grid.rows[0];
+
+  assert.equal(row.cells.length, 12);
+  assert.equal(
+    row.cells.every((cell) => cell.amount === 250 && cell.isGenerated === true),
+    true,
+  );
+});
+
+test("buildBudgetPlanGrid uses existing amounts when present", async () => {
+  const { buildBudgetPlanGrid } = await loadGridTransforms();
+
+  const grid = buildBudgetPlanGrid({
+    categories: [createCategory({ categoryId: "cat-a", monthlyBudget: 120 })],
+    budgetPlan: [
+      {
+        recordId: "rec-existing",
+        categoryId: "cat-a",
+        month: 2,
+        year: 2024,
+        amount: 400,
+        rolloverBalance: 0,
+      },
+    ],
+    startDate: new Date("2024-02-01"),
+  });
+
+  const [first, second] = grid.rows[0].cells;
+
+  assert.equal(first.amount, 400);
+  assert.equal(first.isGenerated, false);
+  assert.equal(second.amount, 120);
+  assert.equal(second.isGenerated, true);
+});
+
+test("buildBudgetPlanGrid computes rollover balances for rollover categories", async () => {
+  const { buildBudgetPlanGrid } = await loadGridTransforms();
+
+  const grid = buildBudgetPlanGrid({
+    categories: [createCategory({ rolloverFlag: true, monthlyBudget: 200 })],
+    budgetPlan: [
+      {
+        recordId: "rec-jan",
+        categoryId: "cat-1",
+        month: 1,
+        year: 2024,
+        amount: 150,
+        rolloverBalance: 0,
+      },
+      {
+        recordId: "rec-feb",
+        categoryId: "cat-1",
+        month: 2,
+        year: 2024,
+        amount: 250,
+        rolloverBalance: 0,
+      },
+      {
+        recordId: "rec-mar",
+        categoryId: "cat-1",
+        month: 3,
+        year: 2024,
+        amount: 100,
+        rolloverBalance: 0,
+      },
+    ],
+    startDate: new Date("2024-01-01"),
+  });
+
+  const row = grid.rows[0];
+  const rolloverBalances = row.cells.map((cell) => cell.rolloverBalance);
+
+  assert.deepEqual(rolloverBalances.slice(0, 6), [0, 50, 0, 100, 100, 100]);
+});
+
+test("buildBudgetPlanGrid generates deterministic record ids for missing months", async () => {
+  const { buildBudgetPlanGrid, generateBudgetPlanRecordId } =
+    await loadGridTransforms();
+
+  const grid = buildBudgetPlanGrid({
+    categories: [createCategory({ categoryId: "cat-123", monthlyBudget: 75 })],
+    budgetPlan: [
+      {
+        recordId: "rec-existing",
+        categoryId: "cat-123",
+        month: 5,
+        year: 2024,
+        amount: 80,
+        rolloverBalance: 0,
+      },
+    ],
+    startDate: new Date("2024-05-01"),
+  });
+
+  const row = grid.rows[0];
+
+  assert.equal(row.cells[0].recordId, "rec-existing");
+
+  const second = row.cells[1];
+  assert.equal(
+    second.recordId,
+    generateBudgetPlanRecordId({
+      categoryId: "cat-123",
+      year: 2024,
+      month: 6,
+    }),
+  );
+  assert.equal(second.isGenerated, true);
+});

--- a/tests/budget-plan-grid.test.cjs
+++ b/tests/budget-plan-grid.test.cjs
@@ -1,0 +1,220 @@
+// ABOUTME: Exercises the budget plan grid UI rendering logic.
+// ABOUTME: Confirms loading, blocking, and currency display behaviors.
+/* eslint-disable @typescript-eslint/no-require-imports */
+require("./helpers/setup-dom.cjs");
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const React = require("react");
+const { act } = require("react");
+const { createRoot } = require("react-dom/client");
+const tsnode = require("ts-node");
+const tsconfigPaths = require("tsconfig-paths");
+const tsconfig = require("../tsconfig.json");
+const { createTestJiti } = require("./helpers/create-jiti");
+const stubJiti = createTestJiti(__filename);
+const {
+  BaseCurrencyProvider,
+  __resetBaseCurrencyTestValue,
+} = stubJiti("./helpers/stubs/base-currency-context");
+
+tsnode.register({
+  transpileOnly: true,
+  project: path.resolve(__dirname, "../tsconfig.json"),
+  compilerOptions: {
+    module: "commonjs",
+    jsx: "react-jsx",
+    moduleResolution: "node",
+  },
+});
+
+tsconfigPaths.register({
+  baseUrl: path.resolve(__dirname, ".."),
+  paths: tsconfig.compilerOptions?.paths ?? {},
+});
+
+async function loadGridComponent() {
+  return require("../src/components/budget-plan/budget-plan-grid");
+}
+
+function renderWithProvider(element) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(BaseCurrencyProvider, null, element));
+  });
+  return {
+    container,
+    unmount() {
+      act(() => {
+        root.unmount();
+      });
+      if (container.parentNode) {
+        container.parentNode.removeChild(container);
+      }
+    },
+  };
+}
+
+function setInputValue(input, value) {
+  const prototype = Object.getPrototypeOf(input);
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, "value");
+
+  if (descriptor?.set) {
+    descriptor.set.call(input, value);
+  } else {
+    input.value = value;
+  }
+}
+
+test("BudgetPlanGrid shows loading indicator", async () => {
+  __resetBaseCurrencyTestValue();
+  const { BudgetPlanGrid } = await loadGridComponent();
+
+  const manager = {
+    status: "loading",
+    blockingMessage: null,
+    error: null,
+    isSaving: false,
+    isDirty: false,
+    months: [],
+    rows: [],
+    lastSavedAt: null,
+    save: async () => {},
+    reset: () => {},
+    setAmount: () => {},
+  };
+
+  const { container, unmount } = renderWithProvider(
+    React.createElement(BudgetPlanGrid, { manager }),
+  );
+
+  assert.match(container.textContent ?? "", /Loading budget plan/i);
+  unmount();
+});
+
+test("BudgetPlanGrid renders blocking message when health fails", async () => {
+  __resetBaseCurrencyTestValue();
+  const { BudgetPlanGrid } = await loadGridComponent();
+
+  const manager = {
+    status: "blocked",
+    blockingMessage: "Spreadsheet issues detected",
+    error: null,
+    isSaving: false,
+    isDirty: false,
+    months: [],
+    rows: [],
+    lastSavedAt: null,
+    save: async () => {},
+    reset: () => {},
+    setAmount: () => {},
+  };
+
+  const { container, unmount } = renderWithProvider(
+    React.createElement(BudgetPlanGrid, { manager }),
+  );
+
+  assert.match(container.textContent ?? "", /Spreadsheet issues detected/);
+  unmount();
+});
+
+test("BudgetPlanGrid displays amounts, approximations, and rollovers", async () => {
+  __resetBaseCurrencyTestValue();
+  const { BudgetPlanGrid } = await loadGridComponent();
+
+  const savedCalls = [];
+  const resetCalls = [];
+  const amountCalls = [];
+
+  const manager = {
+    status: "ready",
+    blockingMessage: null,
+    error: null,
+    isSaving: false,
+    isDirty: true,
+    months: [
+      { id: "2024-05", month: 5, year: 2024, index: 0 },
+      { id: "2024-06", month: 6, year: 2024, index: 1 },
+    ],
+    rows: [
+      {
+        category: {
+          categoryId: "cat-travel",
+          label: "Travel",
+          color: "#ff0000",
+          rolloverFlag: true,
+          currencyCode: "EUR",
+        },
+        cells: [
+          {
+            monthIndex: 0,
+            amount: 150,
+            baseCurrencyDisplay: "~300.00 USD",
+            rolloverBalance: 0,
+            isGenerated: false,
+          },
+          {
+            monthIndex: 1,
+            amount: 180,
+            baseCurrencyDisplay: "~360.00 USD",
+            rolloverBalance: 50,
+            isGenerated: false,
+          },
+        ],
+      },
+    ],
+    lastSavedAt: "2024-05-01T00:00:00.000Z",
+    save: async () => {
+      savedCalls.push(true);
+    },
+    reset: () => {
+      resetCalls.push(true);
+    },
+    setAmount: (categoryId, monthIndex, value) => {
+      amountCalls.push({ categoryId, monthIndex, value });
+    },
+  };
+
+  const { container, unmount } = renderWithProvider(
+    React.createElement(BudgetPlanGrid, { manager }),
+  );
+
+  const amountInput = /** @type {HTMLInputElement | null} */ (
+    container.querySelector('[data-cell="cat-travel:0"]')
+  );
+  assert.ok(amountInput, "amount input found");
+  await act(async () => {
+    setInputValue(amountInput, "200");
+    amountInput.dispatchEvent(new window.Event("input", { bubbles: true }));
+    amountInput.dispatchEvent(new window.Event("change", { bubbles: true }));
+    await Promise.resolve();
+  });
+
+  assert.deepEqual(amountCalls, [
+    { categoryId: "cat-travel", monthIndex: 0, value: 200 },
+  ]);
+
+  const textContent = container.textContent ?? "";
+  assert.match(textContent, /~300\.00 USD/);
+  assert.match(textContent, /Rollover:\s*50/);
+
+  const saveButton = container.querySelector('[data-action="save"]');
+  assert.ok(saveButton, "save button found");
+  await act(async () => {
+    saveButton.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+  });
+
+  assert.equal(savedCalls.length, 1);
+
+  const resetButton = container.querySelector('[data-action="reset"]');
+  assert.ok(resetButton, "reset button found");
+  await act(async () => {
+    resetButton.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+  });
+  assert.equal(resetCalls.length, 1);
+  unmount();
+});

--- a/tests/helpers/setup-dom.cjs
+++ b/tests/helpers/setup-dom.cjs
@@ -1,0 +1,26 @@
+// ABOUTME: Configures a lightweight DOM environment for Node-based tests.
+// ABOUTME: Exposes window, document, and act configuration for React tests.
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { JSDOM } = require("jsdom");
+
+if (typeof globalThis.window === "undefined" || !globalThis.window.document) {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost/",
+  });
+
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.navigator = {
+    ...dom.window.navigator,
+    userAgent: "node.js",
+  };
+  globalThis.requestAnimationFrame =
+    dom.window.requestAnimationFrame?.bind(dom.window) ??
+    ((callback) => setTimeout(callback, 0));
+  globalThis.cancelAnimationFrame =
+    dom.window.cancelAnimationFrame?.bind(dom.window) ?? ((id) => clearTimeout(id));
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+module.exports = {};

--- a/tests/helpers/stubs/base-currency-context.tsx
+++ b/tests/helpers/stubs/base-currency-context.tsx
@@ -1,0 +1,62 @@
+// ABOUTME: Supplies a controllable base currency context for React tests.
+// ABOUTME: Lets tests define conversion and formatting behavior deterministically.
+import React, { createContext, useContext } from "react";
+
+type BaseCurrencyContextValue = {
+  baseCurrency: string;
+  setBaseCurrency: (currency: string) => void;
+  exchangeRates: Record<string, number> | null;
+  isLoadingRates: boolean;
+  rateError: string | null;
+  availableCurrencies: string[];
+  formatAmount: (amount: number, isApproximation?: boolean) => string;
+  convertAmount: (amount: number, fromCurrency: string) => number | null;
+  refreshRates: () => Promise<void>;
+};
+
+const defaultValue: BaseCurrencyContextValue = {
+  baseCurrency: "USD",
+  setBaseCurrency: () => {},
+  exchangeRates: null,
+  isLoadingRates: false,
+  rateError: null,
+  availableCurrencies: ["USD"],
+  formatAmount: (amount: number, isApproximation?: boolean) =>
+    `${isApproximation ? "~" : ""}${amount.toFixed(2)} USD`,
+  convertAmount: (amount: number) => amount,
+  refreshRates: async () => {},
+};
+
+const BaseCurrencyContext = createContext<BaseCurrencyContextValue | null>(defaultValue);
+
+let currentValue: BaseCurrencyContextValue = { ...defaultValue };
+
+export function __setBaseCurrencyTestValue(nextValue: Partial<BaseCurrencyContextValue>) {
+  currentValue = { ...defaultValue, ...nextValue };
+}
+
+export function __resetBaseCurrencyTestValue() {
+  currentValue = { ...defaultValue };
+}
+
+export function BaseCurrencyProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return React.createElement(
+    BaseCurrencyContext.Provider,
+    { value: currentValue },
+    children,
+  );
+}
+
+export function useBaseCurrency() {
+  const context = useContext(BaseCurrencyContext);
+
+  if (!context) {
+    throw new Error("useBaseCurrency must be used within BaseCurrencyProvider");
+  }
+
+  return context;
+}

--- a/tests/helpers/stubs/debug-log.ts
+++ b/tests/helpers/stubs/debug-log.ts
@@ -1,0 +1,6 @@
+// ABOUTME: Replaces debug logging with a no-op for deterministic tests.
+// ABOUTME: Prevents tests from triggering console output or network calls.
+
+export async function debugLog() {
+  // Intentionally empty.
+}

--- a/tests/helpers/stubs/manifest-events.ts
+++ b/tests/helpers/stubs/manifest-events.ts
@@ -1,0 +1,19 @@
+// ABOUTME: Supplies a minimal event emitter for manifest updates in tests.
+// ABOUTME: Allows hooks to react to manifest changes without browser APIs.
+
+type Listener = (manifest: unknown) => void;
+
+const listeners = new Set<Listener>();
+
+export function subscribeToManifestChange(callback: Listener) {
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+export function emitManifestChange(manifest: unknown) {
+  for (const listener of Array.from(listeners)) {
+    listener(manifest);
+  }
+}

--- a/tests/helpers/stubs/manifest-store.ts
+++ b/tests/helpers/stubs/manifest-store.ts
@@ -1,0 +1,25 @@
+// ABOUTME: Mocks the manifest store for client-side unit tests.
+// ABOUTME: Lets tests control the spreadsheet manifest without touching storage.
+
+export interface ManifestRecord {
+  spreadsheetId: string | null;
+  storedAt: number | null;
+}
+
+let currentManifest: ManifestRecord | null = null;
+
+export function __setManifestRecord(manifest: ManifestRecord | null) {
+  currentManifest = manifest;
+}
+
+export function __resetManifestRecord() {
+  currentManifest = null;
+}
+
+export function loadManifest(): ManifestRecord | null {
+  return currentManifest;
+}
+
+export function manifestStorageKey() {
+  return "stub:manifest";
+}

--- a/tests/helpers/stubs/spreadsheet-health-context.tsx
+++ b/tests/helpers/stubs/spreadsheet-health-context.tsx
@@ -1,0 +1,63 @@
+// ABOUTME: Provides a deterministic spreadsheet health context for tests.
+// ABOUTME: Enables simulations of blocking diagnostics without hitting APIs.
+import React, { createContext, useContext } from "react";
+
+type SpreadsheetHealthContextValue = {
+  spreadsheetId: string | null;
+  status: "idle" | "loading" | "ready" | "error";
+  diagnostics: Record<string, unknown> | null;
+  issues: unknown[];
+  error: string | null;
+  lastFetchedAt: number | null;
+  isFetching: boolean;
+  reload: () => Promise<void>;
+};
+
+const defaultValue: SpreadsheetHealthContextValue = {
+  spreadsheetId: null,
+  status: "idle",
+  diagnostics: null,
+  issues: [],
+  error: null,
+  lastFetchedAt: null,
+  isFetching: false,
+  reload: async () => {},
+};
+
+const SpreadsheetHealthContext = createContext<SpreadsheetHealthContextValue | null>(
+  defaultValue,
+);
+
+let currentValue: SpreadsheetHealthContextValue = { ...defaultValue };
+
+export function __setSpreadsheetHealthTestValue(
+  nextValue: Partial<SpreadsheetHealthContextValue>,
+) {
+  currentValue = { ...defaultValue, ...nextValue };
+}
+
+export function __resetSpreadsheetHealthTestValue() {
+  currentValue = { ...defaultValue };
+}
+
+export function SpreadsheetHealthProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return React.createElement(
+    SpreadsheetHealthContext.Provider,
+    { value: currentValue },
+    children,
+  );
+}
+
+export function useSpreadsheetHealth() {
+  const context = useContext(SpreadsheetHealthContext);
+
+  if (!context) {
+    throw new Error("useSpreadsheetHealth must be used within SpreadsheetHealthProvider");
+  }
+
+  return context;
+}

--- a/tests/use-budget-plan-manager.test.cjs
+++ b/tests/use-budget-plan-manager.test.cjs
@@ -1,0 +1,390 @@
+// ABOUTME: Validates the budget plan manager hook behavior end to end.
+// ABOUTME: Covers loading, editing, saving, currencies, and health gating.
+/* eslint-disable @typescript-eslint/no-require-imports */
+require("./helpers/setup-dom.cjs");
+const { test, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const React = require("react");
+const { act } = require("react");
+const { createRoot } = require("react-dom/client");
+const { createTestJiti } = require("./helpers/create-jiti");
+const stubJiti = createTestJiti(__filename);
+const {
+  BaseCurrencyProvider,
+  __setBaseCurrencyTestValue,
+  __resetBaseCurrencyTestValue,
+} = stubJiti("./helpers/stubs/base-currency-context");
+const {
+  SpreadsheetHealthProvider,
+  __setSpreadsheetHealthTestValue,
+  __resetSpreadsheetHealthTestValue,
+} = stubJiti("./helpers/stubs/spreadsheet-health-context");
+const {
+  __setManifestRecord,
+  __resetManifestRecord,
+} = stubJiti("./helpers/stubs/manifest-store");
+
+let originalFetch;
+
+function stubAliases() {
+  return {
+    "@/components/currency/base-currency-context": path.resolve(
+      __dirname,
+      "helpers/stubs/base-currency-context.tsx",
+    ),
+    "@/components/spreadsheet/spreadsheet-health-context": path.resolve(
+      __dirname,
+      "helpers/stubs/spreadsheet-health-context.tsx",
+    ),
+    "@/lib/manifest-store": path.resolve(__dirname, "helpers/stubs/manifest-store.ts"),
+    "@/lib/manifest-events": path.resolve(__dirname, "helpers/stubs/manifest-events.ts"),
+    "@/lib/debug-log": path.resolve(__dirname, "helpers/stubs/debug-log.ts"),
+  };
+}
+
+async function renderManager(options = {}) {
+  const jiti = createTestJiti(__filename, { alias: stubAliases() });
+  const { useBudgetPlanManager } = await jiti.import(
+    "../src/components/budget-plan/use-budget-plan-manager",
+  );
+
+  let latest;
+
+  function TestComponent() {
+    latest = useBudgetPlanManager(options);
+    return null;
+  }
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      React.createElement(
+        BaseCurrencyProvider,
+        null,
+        React.createElement(
+          SpreadsheetHealthProvider,
+          null,
+          React.createElement(TestComponent, null),
+        ),
+      ),
+    );
+  });
+
+  async function flush() {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  await flush();
+  await flush();
+
+  return {
+    get manager() {
+      return latest;
+    },
+    async flush() {
+      await flush();
+      await flush();
+      return latest;
+    },
+    unmount() {
+      act(() => {
+        root.unmount();
+      });
+      if (container.parentNode) {
+        container.parentNode.removeChild(container);
+      }
+    },
+  };
+}
+
+beforeEach(() => {
+  originalFetch = global.fetch;
+  __resetBaseCurrencyTestValue();
+  __resetSpreadsheetHealthTestValue();
+  __resetManifestRecord();
+
+  if (global.window?.localStorage?.clear) {
+    global.window.localStorage.clear();
+  }
+  if (!global.window.addEventListener) {
+    global.window.addEventListener = () => {};
+  }
+  if (!global.window.removeEventListener) {
+    global.window.removeEventListener = () => {};
+  }
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+test("useBudgetPlanManager loads data and computes approximations", async () => {
+  __setBaseCurrencyTestValue({
+    baseCurrency: "USD",
+    convertAmount: (amount, fromCurrency) =>
+      fromCurrency === "USD" ? amount : amount * 2,
+    formatAmount: (amount, isApproximation) =>
+      `${isApproximation ? "~" : "$"}${amount.toFixed(2)} USD`,
+  });
+
+  __setManifestRecord({ spreadsheetId: "sheet-123", storedAt: 0 });
+  __setSpreadsheetHealthTestValue({
+    spreadsheetId: "sheet-123",
+    status: "ready",
+    diagnostics: { warnings: [], errors: [], sheets: [] },
+  });
+
+  const fetchCalls = [];
+  global.fetch = async (url) => {
+    fetchCalls.push(url);
+
+    if (url.startsWith("/api/categories")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          categories: [
+            {
+              categoryId: "cat-travel",
+              label: "Travel",
+              color: "#ff0000",
+              rolloverFlag: true,
+              sortOrder: 1,
+              monthlyBudget: 200,
+              currencyCode: "EUR",
+            },
+            {
+              categoryId: "cat-supplies",
+              label: "Supplies",
+              color: "#00ff00",
+              rolloverFlag: false,
+              sortOrder: 2,
+              monthlyBudget: 100,
+              currencyCode: "USD",
+            },
+          ],
+        }),
+      };
+    }
+
+    if (url.startsWith("/api/budget-plan")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          budgetPlan: [
+            {
+              recordId: "rec-travel-may",
+              categoryId: "cat-travel",
+              month: 5,
+              year: 2024,
+              amount: 150,
+              rolloverBalance: 0,
+            },
+            {
+              recordId: "rec-travel-jun",
+              categoryId: "cat-travel",
+              month: 6,
+              year: 2024,
+              amount: 250,
+              rolloverBalance: 0,
+            },
+            {
+              recordId: "rec-supplies-may",
+              categoryId: "cat-supplies",
+              month: 5,
+              year: 2024,
+              amount: 90,
+              rolloverBalance: 0,
+            },
+          ],
+        }),
+      };
+    }
+
+    throw new Error(`Unhandled fetch ${url}`);
+  };
+
+  const harness = await renderManager({ startDate: new Date("2024-05-01T00:00:00Z") });
+  await harness.flush();
+
+  const manager = harness.manager;
+
+  assert.equal(fetchCalls.length, 2);
+  assert.equal(manager.status, "ready");
+  assert.equal(manager.error, null);
+  assert.equal(manager.blockingMessage, null);
+  assert.equal(manager.rows.length, 2);
+
+  const travelRow = manager.rows[0];
+  assert.equal(travelRow.category.categoryId, "cat-travel");
+  assert.equal(travelRow.cells[0].amount, 150);
+  assert.equal(travelRow.cells[1].rolloverBalance, 50);
+  assert.equal(travelRow.cells[0].baseCurrencyDisplay, "~300.00 USD");
+
+  const suppliesRow = manager.rows[1];
+  assert.equal(suppliesRow.category.categoryId, "cat-supplies");
+  assert.equal(suppliesRow.cells[0].baseCurrencyDisplay, "$90.00 USD");
+
+  harness.unmount();
+});
+
+test("useBudgetPlanManager supports editing and saving the draft grid", async () => {
+  __setBaseCurrencyTestValue({
+    baseCurrency: "USD",
+    convertAmount: (amount) => amount,
+    formatAmount: (amount) => `$${amount.toFixed(2)} USD`,
+  });
+
+  __setManifestRecord({ spreadsheetId: "sheet-789", storedAt: 0 });
+  __setSpreadsheetHealthTestValue({
+    spreadsheetId: "sheet-789",
+    status: "ready",
+    diagnostics: { warnings: [], errors: [], sheets: [] },
+  });
+
+  const responses = {
+    categories: {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        categories: [
+          {
+            categoryId: "cat-ops",
+            label: "Operations",
+            color: "#123456",
+            rolloverFlag: true,
+            sortOrder: 1,
+            monthlyBudget: 300,
+            currencyCode: "USD",
+          },
+        ],
+      }),
+    },
+    loadPlan: {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        budgetPlan: [
+          {
+            recordId: "rec-ops-may",
+            categoryId: "cat-ops",
+            month: 5,
+            year: 2024,
+            amount: 250,
+            rolloverBalance: 0,
+          },
+        ],
+      }),
+    },
+  };
+
+  const postCalls = [];
+
+  global.fetch = async (url, options = {}) => {
+    if (url.startsWith("/api/categories")) {
+      return responses.categories;
+    }
+
+    if (url.startsWith("/api/budget-plan") && options.method !== "POST") {
+      return responses.loadPlan;
+    }
+
+    if (url.startsWith("/api/budget-plan") && options.method === "POST") {
+      postCalls.push(JSON.parse(options.body));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          budgetPlan: postCalls[postCalls.length - 1].budgetPlan,
+        }),
+      };
+    }
+
+    throw new Error(`Unhandled fetch ${url}`);
+  };
+
+  const harness = await renderManager({ startDate: new Date("2024-05-01T00:00:00Z") });
+  await harness.flush();
+
+  let manager = harness.manager;
+
+  assert.equal(manager.isDirty, false);
+  assert.equal(manager.rows[0].cells[0].rolloverBalance, 0);
+
+  await act(async () => {
+    manager.setAmount("cat-ops", 0, 100);
+  });
+
+  await harness.flush();
+  manager = harness.manager;
+
+  assert.equal(manager.isDirty, true);
+  assert.equal(manager.rows[0].cells[0].amount, 100);
+  assert.equal(manager.rows[0].cells[1].rolloverBalance > 0, true);
+
+  await act(async () => {
+    await manager.save();
+  });
+
+  await harness.flush();
+  manager = harness.manager;
+
+  assert.equal(postCalls.length, 1);
+  assert.equal(manager.isDirty, false);
+  assert.equal(manager.isSaving, false);
+
+  harness.unmount();
+});
+
+test("useBudgetPlanManager respects spreadsheet health blocking", async () => {
+  __setBaseCurrencyTestValue({
+    baseCurrency: "USD",
+    convertAmount: (amount) => amount,
+    formatAmount: (amount) => `$${amount.toFixed(2)} USD`,
+  });
+
+  __setManifestRecord({ spreadsheetId: "sheet-blocked", storedAt: 0 });
+  __setSpreadsheetHealthTestValue({
+    spreadsheetId: "sheet-blocked",
+    status: "ready",
+    diagnostics: {
+      warnings: [],
+      errors: [
+        {
+          sheetId: "budget_plan",
+          message: "Headers missing",
+        },
+      ],
+      sheets: [],
+    },
+  });
+
+  const fetchCalls = [];
+  global.fetch = async (...args) => {
+    fetchCalls.push(args);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    };
+  };
+
+  const harness = await renderManager({ startDate: new Date("2024-05-01T00:00:00Z") });
+  await harness.flush();
+
+  const manager = harness.manager;
+
+  assert.equal(fetchCalls.length, 0);
+  assert.equal(manager.status, "blocked");
+  assert.equal(manager.blockingMessage?.includes("budget"), true);
+  assert.equal(manager.rows.length, 0);
+
+  harness.unmount();
+});


### PR DESCRIPTION
## Summary
- add budget plan manager hook and grid components wired into the dashboard
- implement budget-plan domain utilities and client wrappers backed by API
- document the workflow and add jsdom-backed tests for the new UI

## Testing
- npm run lint
- npm test
- npm run build
