### PR TITLE
Add runway timeline API and client components

### DIFF
--- a/src/app/api/runway/route.ts
+++ b/src/app/api/runway/route.ts
@@ -1,0 +1,9 @@
+// ABOUTME: Connects runway route exports to the shared handler factory.
+// ABOUTME: Keeps routing limited to HTTP verbs for Next.js compliance.
+import { createRunwayHandler } from "./runway-handler";
+
+const handlers = createRunwayHandler();
+
+export const GET = handlers.GET;
+
+export type { FetchRunwayProjectionOptions } from "./runway-handler";

--- a/src/app/api/runway/runway-handler.ts
+++ b/src/app/api/runway/runway-handler.ts
@@ -1,0 +1,72 @@
+// ABOUTME: Shared handler factory for runway projection API route.
+// ABOUTME: Fetches projection rows from Sheets and normalizes responses.
+import { NextResponse } from "next/server";
+
+import { getSession } from "@/server/auth/session";
+import { createSheetsClient } from "@/server/google/clients";
+import {
+  createRunwayProjectionRepository,
+  type RunwayProjectionRecord,
+} from "@/server/google/repository/runway-projection-repository";
+
+interface FetchRunwayProjectionOptions {
+  spreadsheetId: string;
+}
+
+type FetchRunwayProjection = (
+  options: FetchRunwayProjectionOptions,
+) => Promise<RunwayProjectionRecord[]>;
+
+async function fetchRunwayProjectionFromSheets({
+  spreadsheetId,
+}: FetchRunwayProjectionOptions) {
+  const session = await getSession();
+
+  if (!session) {
+    throw new Error("Missing authenticated session");
+  }
+
+  const tokens = session.googleTokens;
+
+  if (!tokens?.accessToken || !tokens.refreshToken || !tokens.expiresAt) {
+    throw new Error("Missing Google tokens");
+  }
+
+  const sheets = createSheetsClient(tokens);
+  const repository = createRunwayProjectionRepository({
+    sheets,
+    spreadsheetId,
+  });
+
+  return repository.list();
+}
+
+export function createRunwayHandler({
+  fetchRunwayProjection = fetchRunwayProjectionFromSheets,
+}: { fetchRunwayProjection?: FetchRunwayProjection } = {}) {
+  const GET = async (request: Request) => {
+    const url = new URL(request.url);
+    const spreadsheetId = url.searchParams.get("spreadsheetId")?.trim();
+
+    if (!spreadsheetId) {
+      return NextResponse.json({ error: "Missing spreadsheetId" }, { status: 400 });
+    }
+
+    try {
+      const runway = await fetchRunwayProjection({ spreadsheetId });
+      return NextResponse.json({ runway }, { status: 200 });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      const status =
+        message === "Missing authenticated session" || message === "Missing Google tokens"
+          ? 401
+          : 500;
+
+      return NextResponse.json({ error: message }, { status });
+    }
+  };
+
+  return { GET };
+}
+
+export type { FetchRunwayProjectionOptions };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { BudgetPlanManager } from "@/components/budget-plan/budget-plan-manager"
 import { AccountsManager } from "@/components/accounts/accounts-manager";
 import { SpreadsheetHealthProvider } from "@/components/spreadsheet/spreadsheet-health-context";
 import { SpreadsheetHealthPanel } from "@/components/spreadsheet/spreadsheet-health-panel";
+import { RunwayTimeline } from "@/components/runway-timeline/runway-timeline";
 
 const featureItems = [
   {
@@ -64,6 +65,8 @@ export default async function Home() {
           <BudgetPlanManager />
 
           <AccountsManager />
+
+          <RunwayTimeline />
         </div>
       </SpreadsheetHealthProvider>
 

--- a/src/components/runway-timeline/runway-timeline-view.tsx
+++ b/src/components/runway-timeline/runway-timeline-view.tsx
@@ -1,0 +1,215 @@
+// ABOUTME: Presents the runway timeline state as a table and status cards.
+// ABOUTME: Handles loading, blocked, error, and ready rendering branches.
+"use client";
+
+import { useMemo, type ReactNode } from "react";
+
+import type { RunwayTimelineState, RunwayTimelineRow } from "./use-runway-timeline";
+
+const STOPLIGHT_STYLES: Record<string, { label: string; badge: string; dot: string }> = {
+  green: {
+    label: "Green",
+    badge:
+      "inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:ring-emerald-800/70",
+    dot: "h-2 w-2 rounded-full bg-emerald-500 shadow-sm shadow-emerald-600/30",
+  },
+  yellow: {
+    label: "Yellow",
+    badge:
+      "inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:ring-amber-800/70",
+    dot: "h-2 w-2 rounded-full bg-amber-500 shadow-sm shadow-amber-600/30",
+  },
+  red: {
+    label: "Red",
+    badge:
+      "inline-flex items-center gap-2 rounded-full bg-rose-100 px-3 py-1 text-xs font-medium text-rose-700 ring-1 ring-inset ring-rose-200 dark:bg-rose-900/30 dark:text-rose-200 dark:ring-rose-800/70",
+    dot: "h-2 w-2 rounded-full bg-rose-500 shadow-sm shadow-rose-600/30",
+  },
+  neutral: {
+    label: "Pending",
+    badge:
+      "inline-flex items-center gap-2 rounded-full bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-700 ring-1 ring-inset ring-zinc-200 dark:bg-zinc-800/60 dark:text-zinc-200 dark:ring-zinc-700/70",
+    dot: "h-2 w-2 rounded-full bg-zinc-400 shadow-sm shadow-zinc-500/30",
+  },
+};
+
+function formatUpdatedAt(value: string | null) {
+  if (!value) {
+    return null;
+  }
+
+  const timestamp = Date.parse(value);
+
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(timestamp));
+}
+
+interface StoplightBadgeProps {
+  status: string;
+}
+
+function StoplightBadge({ status }: StoplightBadgeProps) {
+  const normalized = status.toLowerCase();
+  const styles = STOPLIGHT_STYLES[normalized] || STOPLIGHT_STYLES.neutral;
+
+  return (
+    <span className={styles.badge}>
+      <span className={styles.dot} aria-hidden="true" />
+      <span>{styles.label}</span>
+    </span>
+  );
+}
+
+interface TimelineTableProps {
+  rows: RunwayTimelineRow[];
+}
+
+function TimelineTable({ rows }: TimelineTableProps) {
+  return (
+    <div className="overflow-x-auto rounded-xl border border-zinc-200/70 bg-white/60 shadow-sm shadow-zinc-900/5 dark:border-zinc-700/60 dark:bg-zinc-900/70">
+      <table className="min-w-full divide-y divide-zinc-200 text-sm dark:divide-zinc-700">
+        <thead className="bg-zinc-50/80 text-left text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:bg-zinc-800/70 dark:text-zinc-400">
+          <tr>
+            <th scope="col" className="px-4 py-3">Month</th>
+            <th scope="col" className="px-4 py-3">Starting balance</th>
+            <th scope="col" className="px-4 py-3">Income</th>
+            <th scope="col" className="px-4 py-3">Expenses</th>
+            <th scope="col" className="px-4 py-3">Net change</th>
+            <th scope="col" className="px-4 py-3">Ending balance</th>
+            <th scope="col" className="px-4 py-3">Status</th>
+            <th scope="col" className="px-4 py-3">Notes</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-zinc-200/80 dark:divide-zinc-700/80">
+          {rows.map((row) => {
+            const endingClass =
+              row.endingBalanceValue < 0
+                ? "text-rose-600 dark:text-rose-300"
+                : "text-emerald-600 dark:text-emerald-300";
+
+            return (
+              <tr key={row.id} className="bg-white/70 dark:bg-transparent">
+                <th
+                  scope="row"
+                  className="whitespace-nowrap px-4 py-3 text-sm font-medium text-zinc-900 dark:text-zinc-100"
+                >
+                  {row.monthLabel}
+                </th>
+                <td className="whitespace-nowrap px-4 py-3 text-zinc-600 dark:text-zinc-300">
+                  {row.startingBalanceDisplay}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-emerald-600 dark:text-emerald-300">
+                  {row.incomeDisplay}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-rose-600 dark:text-rose-300">
+                  {row.expenseDisplay}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3 text-zinc-700 dark:text-zinc-200">
+                  {row.netChangeDisplay}
+                </td>
+                <td className={`whitespace-nowrap px-4 py-3 font-semibold ${endingClass}`}>
+                  {row.endingBalanceDisplay}
+                </td>
+                <td className="whitespace-nowrap px-4 py-3">
+                  <StoplightBadge status={row.stoplightStatus} />
+                </td>
+                <td className="px-4 py-3 text-zinc-600 dark:text-zinc-300">
+                  {row.notes || "—"}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function RunwayTimelineView({ timeline }: { timeline: RunwayTimelineState }) {
+  const statusLabel = useMemo(() => {
+    switch (timeline.status) {
+      case "loading":
+        return "Loading runway timeline…";
+      case "blocked":
+        return "Runway timeline unavailable";
+      case "error":
+        return "Runway timeline error";
+      default:
+        return "Runway timeline";
+    }
+  }, [timeline.status]);
+
+  const updatedAtLabel = useMemo(
+    () => formatUpdatedAt(timeline.lastUpdatedAt),
+    [timeline.lastUpdatedAt],
+  );
+
+  const refreshDisabled = timeline.status === "loading" || timeline.status === "blocked";
+
+  let body: ReactNode = null;
+
+  if (timeline.status === "loading") {
+    body = (
+      <div className="rounded-xl border border-zinc-200/70 bg-white/60 p-6 text-sm text-zinc-600 shadow-sm shadow-zinc-900/5 dark:border-zinc-700/60 dark:bg-zinc-900/70 dark:text-zinc-300">
+        Loading runway timeline…
+      </div>
+    );
+  } else if (timeline.status === "blocked" && timeline.blockingMessage) {
+    body = (
+      <div className="rounded-xl border border-dashed border-amber-300/70 bg-amber-50/70 p-6 text-sm text-amber-900 dark:border-amber-700/70 dark:bg-amber-900/20 dark:text-amber-100">
+        {timeline.blockingMessage}
+      </div>
+    );
+  } else if (timeline.status === "error") {
+    body = (
+      <div className="rounded-xl border border-rose-200/70 bg-rose-50/60 p-6 text-sm text-rose-900 shadow-sm shadow-rose-900/5 dark:border-rose-800/70 dark:bg-rose-900/20 dark:text-rose-100">
+        {timeline.error ?? "Runway timeline failed to load."}
+      </div>
+    );
+  } else if (timeline.rows.length === 0) {
+    body = (
+      <div className="rounded-xl border border-zinc-200/70 bg-white/60 p-6 text-sm text-zinc-600 shadow-sm shadow-zinc-900/5 dark:border-zinc-700/60 dark:bg-zinc-900/70 dark:text-zinc-300">
+        No runway projection rows yet. Add budget, cash flow, and snapshot data to populate the
+        timeline.
+      </div>
+    );
+  } else {
+    body = <TimelineTable rows={timeline.rows} />;
+  }
+
+  return (
+    <section className="flex flex-col gap-4">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">{statusLabel}</h2>
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            Visualize month-by-month runway by combining starting balances, planned income, and
+            spending.
+          </p>
+          {updatedAtLabel ? (
+            <span className="text-xs uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+              Updated {updatedAtLabel}
+            </span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            void timeline.refresh();
+          }}
+          disabled={refreshDisabled}
+          className="inline-flex items-center justify-center rounded-lg border border-zinc-200/70 bg-white/70 px-4 py-2 text-sm font-medium text-zinc-700 shadow-sm shadow-zinc-900/5 transition hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-zinc-700/60 dark:bg-zinc-900/70 dark:text-zinc-200 dark:hover:bg-zinc-900/60"
+        >
+          Refresh
+        </button>
+      </header>
+      {body}
+    </section>
+  );
+}

--- a/src/components/runway-timeline/runway-timeline.tsx
+++ b/src/components/runway-timeline/runway-timeline.tsx
@@ -1,0 +1,11 @@
+// ABOUTME: Connects the runway timeline hook to the presentational view.
+// ABOUTME: Exposes the component for inclusion on the dashboard.
+"use client";
+
+import { RunwayTimelineView } from "./runway-timeline-view";
+import { useRunwayTimeline } from "./use-runway-timeline";
+
+export function RunwayTimeline() {
+  const timeline = useRunwayTimeline();
+  return <RunwayTimelineView timeline={timeline} />;
+}

--- a/src/components/runway-timeline/use-runway-timeline.ts
+++ b/src/components/runway-timeline/use-runway-timeline.ts
@@ -1,0 +1,238 @@
+// ABOUTME: Loads runway projection rows and maps them into display state.
+// ABOUTME: Watches manifest and spreadsheet health to refresh the timeline.
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useBaseCurrency } from "@/components/currency/base-currency-context";
+import { useSpreadsheetHealth } from "@/components/spreadsheet/spreadsheet-health-context";
+import { filterSheetIssues } from "@/components/spreadsheet/spreadsheet-health-helpers";
+import { fetchRunwayProjection } from "@/lib/api/runway-client";
+import { debugLog } from "@/lib/debug-log";
+import {
+  loadManifest,
+  manifestStorageKey,
+  type ManifestRecord,
+} from "@/lib/manifest-store";
+import { subscribeToManifestChange } from "@/lib/manifest-events";
+import type { SpreadsheetDiagnosticsPayload } from "@/components/spreadsheet/spreadsheet-health-helpers";
+import type { RunwayProjectionRecord } from "@/server/google/repository/runway-projection-repository";
+
+const TIMELINE_SHEET_ID = "runway_projection";
+
+const monthFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "long",
+  year: "numeric",
+});
+
+export type RunwayTimelineStatus = "idle" | "loading" | "ready" | "blocked" | "error";
+
+export interface RunwayTimelineRow {
+  id: string;
+  month: number;
+  year: number;
+  monthLabel: string;
+  startingBalanceDisplay: string;
+  incomeDisplay: string;
+  expenseDisplay: string;
+  endingBalanceDisplay: string;
+  netChangeDisplay: string;
+  endingBalanceValue: number;
+  stoplightStatus: string;
+  notes: string;
+}
+
+export interface RunwayTimelineState {
+  status: RunwayTimelineStatus;
+  blockingMessage: string | null;
+  error: string | null;
+  rows: RunwayTimelineRow[];
+  lastUpdatedAt: string | null;
+  refresh: () => Promise<void>;
+}
+
+function buildTimelineRows(
+  records: RunwayProjectionRecord[],
+  formatAmount: (amount: number, isApproximation?: boolean) => string,
+): RunwayTimelineRow[] {
+  const sorted = [...records].sort((left, right) => {
+    if (left.year !== right.year) {
+      return left.year - right.year;
+    }
+
+    return left.month - right.month;
+  });
+
+  const rows: RunwayTimelineRow[] = [];
+
+  for (const record of sorted) {
+    const id = `${record.year}-${String(record.month).padStart(2, "0")}`;
+    const monthLabel = monthFormatter.format(new Date(record.year, record.month - 1, 1));
+    const netChange = record.endingBalance - record.startingBalance;
+    const netChangeAbsolute = Math.abs(netChange);
+    const netChangeFormatted = formatAmount(netChangeAbsolute);
+    const netChangeDisplay =
+      netChange === 0
+        ? formatAmount(0)
+        : netChange > 0
+        ? `+${netChangeFormatted}`
+        : `-${netChangeFormatted}`;
+
+    rows.push({
+      id,
+      month: record.month,
+      year: record.year,
+      monthLabel,
+      startingBalanceDisplay: formatAmount(record.startingBalance),
+      incomeDisplay: formatAmount(record.incomeTotal),
+      expenseDisplay: formatAmount(record.expenseTotal),
+      endingBalanceDisplay: formatAmount(record.endingBalance),
+      netChangeDisplay,
+      endingBalanceValue: record.endingBalance,
+      stoplightStatus: (record.stoplightStatus || "neutral").toLowerCase(),
+      notes: (record.notes ?? "").trim(),
+    });
+  }
+
+  return rows;
+}
+
+export function useRunwayTimeline(): RunwayTimelineState {
+  const { formatAmount } = useBaseCurrency();
+  const { diagnostics } = useSpreadsheetHealth();
+  const [manifest, setManifest] = useState<ManifestRecord | null>(null);
+  const [status, setStatus] = useState<RunwayTimelineStatus>("idle");
+  const [blockingMessage, setBlockingMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [rows, setRows] = useState<RunwayTimelineRow[]>([]);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null);
+  const activeRequestRef = useRef(0);
+
+  const spreadsheetId = manifest?.spreadsheetId ?? null;
+  const storedAt = manifest?.storedAt ?? null;
+
+  const timelineHealth = useMemo(
+    () =>
+      filterSheetIssues(diagnostics as SpreadsheetDiagnosticsPayload, {
+        sheetId: TIMELINE_SHEET_ID,
+        fallbackTitle: "Runway projection",
+      }),
+    [diagnostics],
+  );
+
+  const hasBlockingErrors = timelineHealth.hasErrors;
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const updateManifest = () => {
+      const stored = loadManifest(window.localStorage);
+      setManifest(stored);
+    };
+
+    updateManifest();
+    void debugLog("Runway timeline loaded manifest", loadManifest(window.localStorage));
+
+    const unsubscribe = subscribeToManifestChange((record) => {
+      setManifest(record);
+    });
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === manifestStorageKey()) {
+        updateManifest();
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      unsubscribe();
+    };
+  }, []);
+
+  const loadProjection = useCallback(
+    async ({ spreadsheetId: id, showLoading }: { spreadsheetId: string; showLoading: boolean }) => {
+      const requestId = Date.now();
+      activeRequestRef.current = requestId;
+
+      if (showLoading) {
+        setStatus("loading");
+        setBlockingMessage(null);
+        setError(null);
+      } else {
+        setError(null);
+      }
+
+      try {
+        const records = await fetchRunwayProjection(id);
+
+        if (activeRequestRef.current !== requestId) {
+          return;
+        }
+
+        const timelineRows = buildTimelineRows(records, formatAmount);
+        setRows(timelineRows);
+        setStatus("ready");
+        setBlockingMessage(null);
+        setError(null);
+        setLastUpdatedAt(new Date().toISOString());
+        void debugLog("Runway timeline loaded", { spreadsheetId: id, rows: timelineRows.length });
+      } catch (loadError) {
+        if (activeRequestRef.current !== requestId) {
+          return;
+        }
+
+        const message =
+          loadError instanceof Error ? loadError.message : "Failed to load runway timeline";
+        setError(message);
+        setStatus("error");
+        void debugLog("Runway timeline load failed", { spreadsheetId: id, message });
+      }
+    },
+    [formatAmount],
+  );
+
+  useEffect(() => {
+    if (!spreadsheetId) {
+      setRows([]);
+      setStatus("blocked");
+      setBlockingMessage("Connect a spreadsheet to view the runway timeline.");
+      setError(null);
+      setLastUpdatedAt(null);
+      return;
+    }
+
+    if (hasBlockingErrors) {
+      setRows([]);
+      setStatus("blocked");
+      setBlockingMessage(
+        "Spreadsheet health flagged issues with the runway projection tab. Fix the spreadsheet issues above, then reload.",
+      );
+      setError(null);
+      setLastUpdatedAt(null);
+      return;
+    }
+
+    void loadProjection({ spreadsheetId, showLoading: true });
+  }, [spreadsheetId, hasBlockingErrors, storedAt, loadProjection]);
+
+  const refresh = useCallback(async () => {
+    if (!spreadsheetId || hasBlockingErrors) {
+      return;
+    }
+
+    await loadProjection({ spreadsheetId, showLoading: true });
+  }, [hasBlockingErrors, loadProjection, spreadsheetId]);
+
+  return {
+    status,
+    blockingMessage,
+    error,
+    rows,
+    lastUpdatedAt,
+    refresh,
+  };
+}

--- a/src/lib/api/runway-client.ts
+++ b/src/lib/api/runway-client.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Wraps runway projection API calls for client-side consumption.
+// ABOUTME: Normalizes responses and raises typed errors for failures.
+import type { RunwayProjectionRecord } from "@/server/google/repository/runway-projection-repository";
+
+const FETCH_ERROR_MESSAGE = "Failed to fetch runway projection";
+
+export class RunwayClientError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "RunwayClientError";
+    this.status = status;
+  }
+}
+
+function ensureSpreadsheetId(value: string) {
+  if (!value || !value.trim()) {
+    throw new Error("Missing spreadsheetId");
+  }
+
+  return value.trim();
+}
+
+async function parseRunwayPayload(response: Response, defaultMessage: string) {
+  const payload = (await response.json().catch(() => ({}))) as {
+    runway?: unknown;
+    error?: unknown;
+  };
+
+  if (!response.ok) {
+    const message =
+      typeof payload?.error === "string" && payload.error.trim()
+        ? payload.error.trim()
+        : defaultMessage;
+
+    throw new RunwayClientError(response.status, message);
+  }
+
+  const rows = Array.isArray(payload?.runway) ? payload.runway : [];
+  return rows as RunwayProjectionRecord[];
+}
+
+export async function fetchRunwayProjection(
+  spreadsheetId: string,
+): Promise<RunwayProjectionRecord[]> {
+  const normalizedId = ensureSpreadsheetId(spreadsheetId);
+  const response = await fetch(
+    `/api/runway?spreadsheetId=${encodeURIComponent(normalizedId)}`,
+  );
+
+  return parseRunwayPayload(response, FETCH_ERROR_MESSAGE);
+}

--- a/tests/helpers/stubs/runway-client.ts
+++ b/tests/helpers/stubs/runway-client.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Provides controllable runway client responses for hook tests.
+// ABOUTME: Captures calls and simulates success or error payloads.
+let nextResponse = [];
+let nextError: Error | null = null;
+const calls: string[] = [];
+
+export class RunwayClientError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "RunwayClientError";
+    this.status = status;
+  }
+}
+
+export function __setRunwayClientResponse(records: unknown[]) {
+  nextResponse = records;
+  nextError = null;
+}
+
+export function __setRunwayClientError(error: Error) {
+  nextError = error;
+}
+
+export function __resetRunwayClientStub() {
+  nextResponse = [];
+  nextError = null;
+  calls.length = 0;
+}
+
+export function __getRunwayClientCalls() {
+  return calls.slice();
+}
+
+export async function fetchRunwayProjection(spreadsheetId: string) {
+  calls.push(spreadsheetId);
+
+  if (nextError) {
+    throw nextError;
+  }
+
+  return nextResponse;
+}

--- a/tests/runway-client.test.cjs
+++ b/tests/runway-client.test.cjs
@@ -1,0 +1,115 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { createTestJiti } = require("./helpers/create-jiti");
+
+async function withMockedFetch(handler, run) {
+  const originalFetch = global.fetch;
+  const calls = [];
+
+  global.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return handler(url, options);
+  };
+
+  try {
+    await run({ calls });
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+test("fetchRunwayProjection requests runway data and returns rows", async () => {
+  const jiti = createTestJiti(__filename);
+  const clientModule = await jiti.import("../src/lib/api/runway-client");
+  const { fetchRunwayProjection } = clientModule;
+
+  await withMockedFetch(
+    async (url) => {
+      assert.equal(url, "/api/runway?spreadsheetId=sheet-123");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          runway: [
+            {
+              month: 1,
+              year: 2025,
+              startingBalance: 10000,
+              incomeTotal: 6000,
+              expenseTotal: 4000,
+              endingBalance: 12000,
+              stoplightStatus: "green",
+              notes: "stable",
+            },
+          ],
+        }),
+      };
+    },
+    async () => {
+      const records = await fetchRunwayProjection("sheet-123");
+      assert.deepEqual(records, [
+        {
+          month: 1,
+          year: 2025,
+          startingBalance: 10000,
+          incomeTotal: 6000,
+          expenseTotal: 4000,
+          endingBalance: 12000,
+          stoplightStatus: "green",
+          notes: "stable",
+        },
+      ]);
+    },
+  );
+});
+
+test("fetchRunwayProjection throws RunwayClientError on failure", async () => {
+  const jiti = createTestJiti(__filename);
+  const clientModule = await jiti.import("../src/lib/api/runway-client");
+  const { fetchRunwayProjection, RunwayClientError } = clientModule;
+
+  await withMockedFetch(
+    async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "Missing authenticated session" }),
+    }),
+    async () => {
+      await assert.rejects(
+        () => fetchRunwayProjection("sheet-abc"),
+        (error) => {
+          assert.equal(error instanceof RunwayClientError, true);
+          assert.equal(error.message, "Missing authenticated session");
+          assert.equal(error.status, 401);
+          return true;
+        },
+      );
+    },
+  );
+});
+
+test("fetchRunwayProjection uses default message when error missing", async () => {
+  const jiti = createTestJiti(__filename);
+  const clientModule = await jiti.import("../src/lib/api/runway-client");
+  const { fetchRunwayProjection, RunwayClientError } = clientModule;
+
+  await withMockedFetch(
+    async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    }),
+    async () => {
+      await assert.rejects(
+        () => fetchRunwayProjection("sheet-xyz"),
+        (error) => {
+          assert.equal(error instanceof RunwayClientError, true);
+          assert.equal(error.message, "Failed to fetch runway projection");
+          assert.equal(error.status, 500);
+          return true;
+        },
+      );
+    },
+  );
+});

--- a/tests/runway-route.test.cjs
+++ b/tests/runway-route.test.cjs
@@ -1,0 +1,116 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { createTestJiti } = require("./helpers/create-jiti");
+
+function withEnv(run) {
+  const originalClientId = process.env.GOOGLE_CLIENT_ID;
+  const originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
+
+  process.env.GOOGLE_CLIENT_ID = "test-client-id";
+  process.env.GOOGLE_CLIENT_SECRET = "test-client-secret";
+
+  return (async () => {
+    try {
+      await run();
+    } finally {
+      process.env.GOOGLE_CLIENT_ID = originalClientId;
+      process.env.GOOGLE_CLIENT_SECRET = originalClientSecret;
+    }
+  })();
+}
+
+test("runway route requires spreadsheetId query", async () => {
+  await withEnv(async () => {
+    const jiti = createTestJiti(__filename);
+    const { createRunwayHandler } = await jiti.import(
+      "../src/app/api/runway/runway-handler",
+    );
+
+    const { GET } = createRunwayHandler({
+      fetchRunwayProjection: async () => {
+        throw new Error("should not be called");
+      },
+    });
+
+    const request = new Request("http://localhost/api/runway");
+    const response = await GET(request);
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.error, "Missing spreadsheetId");
+  });
+});
+
+test("runway route maps auth errors to 401", async () => {
+  await withEnv(async () => {
+    const jiti = createTestJiti(__filename);
+    const { createRunwayHandler } = await jiti.import(
+      "../src/app/api/runway/runway-handler",
+    );
+
+    const { GET } = createRunwayHandler({
+      fetchRunwayProjection: async () => {
+        throw new Error("Missing authenticated session");
+      },
+    });
+
+    const request = new Request(
+      "http://localhost/api/runway?spreadsheetId=sheet-123",
+    );
+    const response = await GET(request);
+    const payload = await response.json();
+
+    assert.equal(response.status, 401);
+    assert.equal(payload.error, "Missing authenticated session");
+  });
+});
+
+test("runway route returns projection data on success", async () => {
+  await withEnv(async () => {
+    const jiti = createTestJiti(__filename);
+    const { createRunwayHandler } = await jiti.import(
+      "../src/app/api/runway/runway-handler",
+    );
+
+    const { GET } = createRunwayHandler({
+      fetchRunwayProjection: async ({ spreadsheetId }) => {
+        assert.equal(spreadsheetId, "sheet-abc");
+        return [
+          {
+            month: 1,
+            year: 2025,
+            startingBalance: 10000,
+            incomeTotal: 6000,
+            expenseTotal: 4000,
+            endingBalance: 12000,
+            stoplightStatus: "green",
+            notes: "stable",
+          },
+        ];
+      },
+    });
+
+    const request = new Request(
+      "http://localhost/api/runway?spreadsheetId=sheet-abc",
+    );
+    const response = await GET(request);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, {
+      runway: [
+        {
+          month: 1,
+          year: 2025,
+          startingBalance: 10000,
+          incomeTotal: 6000,
+          expenseTotal: 4000,
+          endingBalance: 12000,
+          stoplightStatus: "green",
+          notes: "stable",
+        },
+      ],
+    });
+  });
+});

--- a/tests/runway-timeline-view.test.cjs
+++ b/tests/runway-timeline-view.test.cjs
@@ -1,0 +1,154 @@
+// ABOUTME: Ensures the runway timeline view renders states and rows.
+/* eslint-disable @typescript-eslint/no-require-imports */
+require("./helpers/setup-dom.cjs");
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const React = require("react");
+const { act } = require("react");
+const { createRoot } = require("react-dom/client");
+const tsnode = require("ts-node");
+const tsconfigPaths = require("tsconfig-paths");
+const tsconfig = require("../tsconfig.json");
+tsnode.register({
+  transpileOnly: true,
+  project: path.resolve(__dirname, "../tsconfig.json"),
+  compilerOptions: {
+    module: "commonjs",
+    jsx: "react-jsx",
+    moduleResolution: "node",
+  },
+});
+
+tsconfigPaths.register({
+  baseUrl: path.resolve(__dirname, ".."),
+  paths: tsconfig.compilerOptions?.paths ?? {},
+});
+
+async function loadView() {
+  return require("../src/components/runway-timeline/runway-timeline-view");
+}
+
+function render(element) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(element);
+  });
+
+  return {
+    container,
+    unmount() {
+      act(() => {
+        root.unmount();
+      });
+      if (container.parentNode) {
+        container.parentNode.removeChild(container);
+      }
+    },
+  };
+}
+
+test("RunwayTimelineView shows loading state", async () => {
+  const { RunwayTimelineView } = await loadView();
+  const timeline = {
+    status: "loading",
+    blockingMessage: null,
+    error: null,
+    rows: [],
+    lastUpdatedAt: null,
+    refresh: async () => {},
+  };
+
+  const { container, unmount } = render(
+    React.createElement(RunwayTimelineView, { timeline }),
+  );
+
+  assert.match(container.textContent ?? "", /Loading runway timeline/i);
+  unmount();
+});
+
+test("RunwayTimelineView shows blocking message", async () => {
+  const { RunwayTimelineView } = await loadView();
+  const timeline = {
+    status: "blocked",
+    blockingMessage: "Fix the runway projection tab",
+    error: null,
+    rows: [],
+    lastUpdatedAt: null,
+    refresh: async () => {},
+  };
+
+  const { container, unmount } = render(
+    React.createElement(RunwayTimelineView, { timeline }),
+  );
+
+  assert.match(container.textContent ?? "", /Fix the runway projection tab/);
+  unmount();
+});
+
+test("RunwayTimelineView renders projection rows", async () => {
+  const { RunwayTimelineView } = await loadView();
+  const refreshCalls = [];
+  const timeline = {
+    status: "ready",
+    blockingMessage: null,
+    error: null,
+    rows: [
+      {
+        id: "2025-01",
+        month: 1,
+        year: 2025,
+        monthLabel: "January 2025",
+        startingBalanceDisplay: "10,000.00 USD",
+        incomeDisplay: "6,000.00 USD",
+        expenseDisplay: "4,000.00 USD",
+        endingBalanceDisplay: "12,000.00 USD",
+        netChangeDisplay: "+2,000.00 USD",
+        endingBalanceValue: 12000,
+        stoplightStatus: "green",
+        notes: "stable",
+      },
+      {
+        id: "2025-02",
+        month: 2,
+        year: 2025,
+        monthLabel: "February 2025",
+        startingBalanceDisplay: "12,000.00 USD",
+        incomeDisplay: "3,000.00 USD",
+        expenseDisplay: "5,000.00 USD",
+        endingBalanceDisplay: "10,000.00 USD",
+        netChangeDisplay: "-2,000.00 USD",
+        endingBalanceValue: 10000,
+        stoplightStatus: "yellow",
+        notes: "monitor",
+      },
+    ],
+    lastUpdatedAt: "2025-03-01T12:00:00.000Z",
+    refresh: async () => {
+      refreshCalls.push(Date.now());
+    },
+  };
+
+  const { container, unmount } = render(
+    React.createElement(RunwayTimelineView, { timeline }),
+  );
+
+  assert.match(container.textContent ?? "", /January 2025/);
+  assert.match(container.textContent ?? "", /12,000.00 USD/);
+  assert.match(container.textContent ?? "", /Net change/);
+
+  const buttons = Array.from(container.querySelectorAll("button"));
+  const refreshButton = buttons.find((button) => /Refresh/.test(button.textContent ?? ""));
+  assert.ok(refreshButton);
+
+  await act(async () => {
+    refreshButton.click();
+    await Promise.resolve();
+  });
+
+  assert.equal(refreshCalls.length, 1);
+  unmount();
+});

--- a/tests/use-runway-timeline.test.cjs
+++ b/tests/use-runway-timeline.test.cjs
@@ -1,0 +1,244 @@
+// ABOUTME: Validates runway timeline hook behaviour across scenarios.
+/* eslint-disable @typescript-eslint/no-require-imports */
+require("./helpers/setup-dom.cjs");
+const { test, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const React = require("react");
+const { act } = require("react");
+const { createRoot } = require("react-dom/client");
+const tsnode = require("ts-node");
+const tsconfigPaths = require("tsconfig-paths");
+const tsconfig = require("../tsconfig.json");
+const { createTestJiti } = require("./helpers/create-jiti");
+
+const stubJiti = createTestJiti(__filename);
+const {
+  BaseCurrencyProvider,
+  __resetBaseCurrencyTestValue,
+} = stubJiti("./helpers/stubs/base-currency-context");
+const {
+  SpreadsheetHealthProvider,
+  __setSpreadsheetHealthTestValue,
+  __resetSpreadsheetHealthTestValue,
+} = stubJiti("./helpers/stubs/spreadsheet-health-context");
+const {
+  __setManifestRecord,
+  __resetManifestRecord,
+} = stubJiti("./helpers/stubs/manifest-store");
+const {
+  emitManifestChange,
+} = stubJiti("./helpers/stubs/manifest-events");
+const {
+  __setRunwayClientResponse,
+  __setRunwayClientError,
+  __resetRunwayClientStub,
+  __getRunwayClientCalls,
+  RunwayClientError,
+} = stubJiti("./helpers/stubs/runway-client");
+
+let originalFetch;
+
+tsnode.register({
+  transpileOnly: true,
+  project: path.resolve(__dirname, "../tsconfig.json"),
+  compilerOptions: {
+    module: "commonjs",
+    jsx: "react-jsx",
+    moduleResolution: "node",
+  },
+});
+
+tsconfigPaths.register({
+  baseUrl: path.resolve(__dirname, ".."),
+  paths: tsconfig.compilerOptions?.paths ?? {},
+});
+
+function stubAliases() {
+  return {
+    "@/components/currency/base-currency-context": path.resolve(
+      __dirname,
+      "helpers/stubs/base-currency-context.tsx",
+    ),
+    "@/components/spreadsheet/spreadsheet-health-context": path.resolve(
+      __dirname,
+      "helpers/stubs/spreadsheet-health-context.tsx",
+    ),
+    "@/lib/manifest-store": path.resolve(__dirname, "helpers/stubs/manifest-store.ts"),
+    "@/lib/manifest-events": path.resolve(
+      __dirname,
+      "helpers/stubs/manifest-events.ts",
+    ),
+    "@/lib/api/runway-client": path.resolve(
+      __dirname,
+      "helpers/stubs/runway-client.ts",
+    ),
+    "@/lib/debug-log": path.resolve(__dirname, "helpers/stubs/debug-log.ts"),
+  };
+}
+
+async function renderTimeline() {
+  const jiti = createTestJiti(__filename, { alias: stubAliases() });
+  const { useRunwayTimeline } = await jiti.import(
+    "../src/components/runway-timeline/use-runway-timeline",
+  );
+
+  let latest;
+
+  function TestComponent() {
+    latest = useRunwayTimeline();
+    return null;
+  }
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      React.createElement(
+        BaseCurrencyProvider,
+        null,
+        React.createElement(
+          SpreadsheetHealthProvider,
+          null,
+          React.createElement(TestComponent, null),
+        ),
+      ),
+    );
+  });
+
+  async function flush() {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  await flush();
+  await flush();
+
+  return {
+    get timeline() {
+      return latest;
+    },
+    async flush() {
+      await flush();
+      await flush();
+      return latest;
+    },
+    unmount() {
+      act(() => {
+        root.unmount();
+      });
+      if (container.parentNode) {
+        container.parentNode.removeChild(container);
+      }
+    },
+  };
+}
+
+beforeEach(() => {
+  originalFetch = global.fetch;
+  global.fetch = async () => ({ ok: true, json: async () => ({}) });
+  __resetBaseCurrencyTestValue();
+  __resetSpreadsheetHealthTestValue();
+  __resetManifestRecord();
+  __resetRunwayClientStub();
+  if (global.window?.localStorage?.clear) {
+    global.window.localStorage.clear();
+  }
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+test("useRunwayTimeline loads projection rows when manifest available", async () => {
+  __setManifestRecord({ spreadsheetId: "sheet-123", storedAt: 1 });
+  __setRunwayClientResponse([
+    {
+      month: 1,
+      year: 2025,
+      startingBalance: 10000,
+      incomeTotal: 6000,
+      expenseTotal: 4000,
+      endingBalance: 12000,
+      stoplightStatus: "green",
+      notes: "steady",
+    },
+  ]);
+
+  const view = await renderTimeline();
+  await view.flush();
+
+  const timeline = view.timeline;
+  assert.equal(timeline.status, "ready");
+  assert.equal(timeline.rows.length, 1);
+  assert.equal(timeline.rows[0].monthLabel, "January 2025");
+  assert.equal(timeline.rows[0].endingBalanceDisplay.includes("12000.00"), true);
+  assert.deepEqual(__getRunwayClientCalls(), ["sheet-123"]);
+  view.unmount();
+});
+
+test("useRunwayTimeline blocks when health reports errors", async () => {
+  __setManifestRecord({ spreadsheetId: "sheet-xyz", storedAt: 2 });
+  __setSpreadsheetHealthTestValue({
+    diagnostics: {
+      warnings: [],
+      errors: [
+        {
+          sheetId: "runway_projection",
+          sheetTitle: "Runway projection",
+          message: "Header mismatch",
+        },
+      ],
+      sheets: [],
+    },
+  });
+
+  const view = await renderTimeline();
+  await view.flush();
+
+  const timeline = view.timeline;
+  assert.equal(timeline.status, "blocked");
+  assert.match(timeline.blockingMessage ?? "", /Fix the spreadsheet/i);
+  assert.equal(timeline.rows.length, 0);
+  assert.equal(__getRunwayClientCalls().length, 0);
+  view.unmount();
+});
+
+test("useRunwayTimeline exposes error message when fetch fails", async () => {
+  __setManifestRecord({ spreadsheetId: "sheet-err", storedAt: 3 });
+  __setRunwayClientError(new RunwayClientError(500, "Failed to fetch"));
+
+  const view = await renderTimeline();
+  await view.flush();
+
+  const timeline = view.timeline;
+  assert.equal(timeline.status, "error");
+  assert.equal(timeline.error, "Failed to fetch");
+  view.unmount();
+});
+
+test("useRunwayTimeline waits for manifest selection", async () => {
+  __setManifestRecord(null);
+
+  const view = await renderTimeline();
+  await view.flush();
+
+  let timeline = view.timeline;
+  assert.equal(timeline.status, "blocked");
+  assert.match(timeline.blockingMessage ?? "", /Connect a spreadsheet/i);
+  assert.equal(__getRunwayClientCalls().length, 0);
+
+  __setManifestRecord({ spreadsheetId: "sheet-activate", storedAt: 4 });
+  await act(async () => {
+    emitManifestChange({ spreadsheetId: "sheet-activate", storedAt: 4 });
+    await Promise.resolve();
+  });
+  await view.flush();
+
+  timeline = view.timeline;
+  assert.equal(timeline.status, "ready");
+  view.unmount();
+});


### PR DESCRIPTION
## Summary
- add runway timeline API handler and client fetch helper
- implement runway timeline hook and view with tests
- wire the timeline into the dashboard layout

## Testing
- npm run lint
- npm test
- npm run build *(fails: unable to fetch Google font assets in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa76e4566c832d8eb524cb35c7fe06