### PR TITLE
Gate snapshot capture on persisted accounts

### DIFF
--- a/src/components/accounts/snapshot-utils.ts
+++ b/src/components/accounts/snapshot-utils.ts
@@ -1,0 +1,27 @@
+export interface SnapshotAvailabilityOptions {
+  isPersisted: boolean;
+  snapshotActionsDisabled: boolean;
+  hasSnapshotBlockingErrors: boolean;
+  hasAccountBlockingErrors: boolean;
+}
+
+export function getSnapshotDisabledReason({
+  isPersisted,
+  snapshotActionsDisabled,
+  hasSnapshotBlockingErrors,
+  hasAccountBlockingErrors,
+}: SnapshotAvailabilityOptions): string | null {
+  if (snapshotActionsDisabled) {
+    if (hasSnapshotBlockingErrors && !hasAccountBlockingErrors) {
+      return "Snapshot capture is disabled until the snapshots tab passes health checks.";
+    }
+
+    return null;
+  }
+
+  if (!isPersisted) {
+    return "Save the account before capturing snapshots.";
+  }
+
+  return null;
+}

--- a/tests/accounts-manager-utils.test.cjs
+++ b/tests/accounts-manager-utils.test.cjs
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { createTestJiti } = require("./helpers/create-jiti");
+
+test("getSnapshotDisabledReason prefers health warnings when snapshots tab failing", async () => {
+  const jiti = createTestJiti(__filename);
+  const { getSnapshotDisabledReason } = await jiti.import(
+    "../src/components/accounts/snapshot-utils",
+  );
+
+  const reason = getSnapshotDisabledReason({
+    isPersisted: true,
+    snapshotActionsDisabled: true,
+    hasSnapshotBlockingErrors: true,
+    hasAccountBlockingErrors: false,
+  });
+
+  assert.equal(
+    reason,
+    "Snapshot capture is disabled until the snapshots tab passes health checks.",
+  );
+});
+
+test("getSnapshotDisabledReason warns on draft accounts", async () => {
+  const jiti = createTestJiti(__filename);
+  const { getSnapshotDisabledReason } = await jiti.import(
+    "../src/components/accounts/snapshot-utils",
+  );
+
+  const reason = getSnapshotDisabledReason({
+    isPersisted: false,
+    snapshotActionsDisabled: false,
+    hasSnapshotBlockingErrors: false,
+    hasAccountBlockingErrors: false,
+  });
+
+  assert.equal(reason, "Save the account before capturing snapshots.");
+});
+
+test("getSnapshotDisabledReason returns null when capture allowed", async () => {
+  const jiti = createTestJiti(__filename);
+  const { getSnapshotDisabledReason } = await jiti.import(
+    "../src/components/accounts/snapshot-utils",
+  );
+
+  const reason = getSnapshotDisabledReason({
+    isPersisted: true,
+    snapshotActionsDisabled: false,
+    hasSnapshotBlockingErrors: false,
+    hasAccountBlockingErrors: false,
+  });
+
+  assert.equal(reason, null);
+});


### PR DESCRIPTION
## Summary
- prevent draft accounts from opening the snapshot modal and explain why in-line
- ensure snapshot API rejects unknown account IDs and reports a 400 level error
- add focused utilities/tests to cover both the UI helper and the API validation

## Testing
- node --test tests/snapshots-route.test.cjs
- node --test tests/accounts-manager-utils.test.cjs