### PR TITLE
feat: automate staging alias from PR comments

### DIFF
--- a/.github/workflows/pr-alias.yml
+++ b/.github/workflows/pr-alias.yml
@@ -1,0 +1,53 @@
+name: PR Staging Alias
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+  deployments: read
+  actions: read
+
+jobs:
+  alias-staging:
+    if: >
+      github.event.issue.pull_request != null &&
+      github.event.comment.body == '/alias this'
+    runs-on: ubuntu-latest
+    env:
+      TS_NODE_COMPILER_OPTIONS: '{"module":"commonjs","moduleResolution":"node","esModuleInterop":true}'
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Alias latest Vercel preview to staging
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          VERCEL_ALIAS_DOMAIN: ${{ secrets.VERCEL_ALIAS_DOMAIN }}
+        run: |
+          npx ts-node --transpile-only scripts/alias-staging.ts

--- a/scripts/alias-staging.ts
+++ b/scripts/alias-staging.ts
@@ -1,0 +1,585 @@
+import process from "node:process";
+
+type PermissionLevel = "none" | "read" | "triage" | "write" | "maintain" | "admin";
+
+export interface GitHubPermissionClient {
+  getCollaboratorPermissionLevel(
+    username: string
+  ): Promise<PermissionLevel | "unknown">;
+}
+
+export interface GitHubPullRequestInfo {
+  head: {
+    ref: string;
+    sha?: string;
+  };
+}
+
+export interface GitHubPullRequestClient {
+  getPullRequest(number: number): Promise<GitHubPullRequestInfo>;
+}
+
+export interface GitHubCommentClient {
+  createComment(body: string): Promise<void>;
+}
+
+export interface GitHubClient
+  extends GitHubPermissionClient,
+    GitHubCommentClient,
+    GitHubPullRequestClient {}
+
+export interface VercelAliasInfo {
+  deploymentId?: string;
+  url?: string;
+}
+
+export interface VercelDeployment {
+  id: string;
+  url?: string;
+  createdAt?: number;
+}
+
+export interface VercelClient {
+  getCurrentAlias(domain: string): Promise<VercelAliasInfo | null>;
+  getLatestDeploymentForBranch(branch: string): Promise<VercelDeployment | null>;
+  setAlias(domain: string, deploymentId: string): Promise<void>;
+}
+
+export function isAliasCommand(body: string): boolean {
+  return body.trim() === "/alias this";
+}
+
+const ALLOWED_PERMISSIONS: PermissionLevel[] = ["write", "maintain", "admin"];
+
+export async function checkWriteAccess(
+  client: GitHubPermissionClient,
+  params: { owner: string; repo: string; username: string }
+): Promise<boolean> {
+  const level = await client.getCollaboratorPermissionLevel(params.username);
+  if (level === "unknown") {
+    return false;
+  }
+  return ALLOWED_PERMISSIONS.includes(level);
+}
+
+export interface AliasResult {
+  deploymentId: string;
+  deploymentUrl?: string;
+  previousDeploymentId?: string;
+}
+
+export class MissingDeploymentError extends Error {
+  branch: string;
+
+  constructor(branch: string) {
+    super(`No successful Vercel preview deployment found for branch "${branch}".`);
+    this.name = "MissingDeploymentError";
+    this.branch = branch;
+  }
+}
+
+export class AliasFailedError extends Error {
+  attemptedDeploymentId: string;
+  previousDeploymentId?: string;
+  rollbackRestored: boolean;
+  rollbackError?: unknown;
+
+  constructor(
+    attemptedDeploymentId: string,
+    message: string,
+    options: {
+      previousDeploymentId?: string;
+      rollbackRestored?: boolean;
+      rollbackError?: unknown;
+      cause?: unknown;
+    } = {}
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "AliasFailedError";
+    this.attemptedDeploymentId = attemptedDeploymentId;
+    this.previousDeploymentId = options.previousDeploymentId;
+    this.rollbackRestored = options.rollbackRestored ?? false;
+    this.rollbackError = options.rollbackError;
+  }
+}
+
+export async function aliasLatestPreview(params: {
+  branch: string;
+  aliasDomain: string;
+  vercelClient: VercelClient;
+}): Promise<AliasResult> {
+  const { branch, aliasDomain, vercelClient } = params;
+  const current = await vercelClient.getCurrentAlias(aliasDomain);
+  const latest = await vercelClient.getLatestDeploymentForBranch(branch);
+  if (!latest) {
+    throw new MissingDeploymentError(branch);
+  }
+
+  try {
+    await vercelClient.setAlias(aliasDomain, latest.id);
+    return {
+      deploymentId: latest.id,
+      deploymentUrl: normalizeDeploymentUrl(latest.url),
+      previousDeploymentId: current?.deploymentId,
+    };
+  } catch (error) {
+    let rollbackRestored = false;
+    let rollbackError: unknown;
+    if (current?.deploymentId) {
+      try {
+        await vercelClient.setAlias(aliasDomain, current.deploymentId);
+        rollbackRestored = true;
+      } catch (rollbackFailure) {
+        rollbackError = rollbackFailure;
+      }
+    }
+
+    throw new AliasFailedError(latest.id, getErrorMessage(error), {
+      previousDeploymentId: current?.deploymentId,
+      rollbackRestored,
+      rollbackError,
+      cause: error,
+    });
+  }
+}
+
+export function formatSuccessComment(params: {
+  requestor: string;
+  aliasDomain: string;
+  deploymentUrl?: string;
+}): string {
+  const { requestor, aliasDomain, deploymentUrl } = params;
+  const lines = [
+    `@${requestor} staging alias updated ✅`,
+    "",
+    `- alias: \`${aliasDomain}\``,
+  ];
+
+  if (deploymentUrl) {
+    lines.push(`- deployment: ${deploymentUrl}`);
+  }
+
+  lines.push("", "Feel free to sanity-check the staging site and follow up if anything looks off.");
+  return lines.join("\n");
+}
+
+export function formatFailureComment(params: {
+  requestor: string;
+  reason: string;
+}): string {
+  const { requestor, reason } = params;
+  return [
+    `@${requestor} staging alias update failed ❌`,
+    "",
+    reason,
+    "",
+    "Please inspect the workflow logs (Actions tab) and Vercel dashboard for more context.",
+  ].join("\n");
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function normalizeDeploymentUrl(url?: string | null): string | undefined {
+  if (!url) return undefined;
+  if (url.startsWith("http://") || url.startsWith("https://")) {
+    return url;
+  }
+  return `https://${url}`;
+}
+
+class RestGitHubClient implements GitHubClient {
+  private readonly baseUrl: string;
+
+  constructor(
+    private readonly options: {
+      token: string;
+      owner: string;
+      repo: string;
+      issueNumber: number;
+      pullNumber: number;
+    }
+  ) {
+    this.baseUrl = "https://api.github.com";
+  }
+
+  async getCollaboratorPermissionLevel(username: string): Promise<PermissionLevel | "unknown"> {
+    const { owner, repo } = this.options;
+    const response = await this.request(
+      `/repos/${owner}/${repo}/collaborators/${encodeURIComponent(username)}/permission`,
+      { method: "GET" }
+    );
+
+    if (response.status === 404) {
+      return "none";
+    }
+
+    if (!response.ok) {
+      return "unknown";
+    }
+
+    const payload = (await response.json()) as { permission?: PermissionLevel };
+    return payload.permission ?? "unknown";
+  }
+
+  async createComment(body: string): Promise<void> {
+    const { owner, repo, issueNumber } = this.options;
+    const response = await this.request(
+      `/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+      {
+        method: "POST",
+        body: JSON.stringify({ body }),
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Failed to create GitHub comment (${response.status}): ${text || response.statusText}`
+      );
+    }
+  }
+
+  async getPullRequest(number: number): Promise<GitHubPullRequestInfo> {
+    const { owner, repo } = this.options;
+    const response = await this.request(
+      `/repos/${owner}/${repo}/pulls/${number}`,
+      { method: "GET" }
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Failed to load pull request #${number} (${response.status}): ${text || response.statusText}`
+      );
+    }
+
+    const payload = (await response.json()) as {
+      head: { ref: string; sha?: string };
+    };
+    return payload;
+  }
+
+  private request(path: string, init: RequestInit): Promise<Response> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${this.options.token}`,
+      "User-Agent": "runway-compass-staging-alias",
+    };
+
+    const merged: RequestInit = {
+      ...init,
+      headers: {
+        ...headers,
+        ...(init.headers as Record<string, string> | undefined),
+      },
+    };
+
+    return fetch(url, merged);
+  }
+}
+
+class RestVercelClient implements VercelClient {
+  constructor(
+    private readonly options: {
+      token: string;
+      projectId: string;
+      teamId?: string;
+    }
+  ) {}
+
+  async getCurrentAlias(domain: string): Promise<VercelAliasInfo | null> {
+    const url = this.buildUrl(`/v2/aliases/${domain}`);
+    const response = await fetch(url, {
+      method: "GET",
+      headers: this.headers(),
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Failed to resolve current alias (${response.status}): ${text || response.statusText}`
+      );
+    }
+
+    const data = (await response.json()) as {
+      alias?: {
+        alias?: string;
+        url?: string;
+        deploymentId?: string;
+        targetDeploymentId?: string;
+      };
+      aliasId?: string;
+      url?: string;
+      deploymentId?: string;
+      targetDeploymentId?: string;
+    };
+
+    // Support both alias-level envelope and top-level payload.
+    const source = data.alias ?? data;
+    const deploymentId =
+      source?.deploymentId ?? source?.targetDeploymentId ?? undefined;
+    const urlString =
+      source?.url ?? (typeof source?.alias === "string" ? `https://${source.alias}` : undefined);
+
+    return {
+      deploymentId,
+      url: normalizeDeploymentUrl(urlString),
+    };
+  }
+
+  async getLatestDeploymentForBranch(branch: string): Promise<VercelDeployment | null> {
+    const search = new URLSearchParams({
+      projectId: this.options.projectId,
+      target: "preview",
+      state: "READY",
+      limit: "20",
+    });
+
+    if (this.options.teamId) {
+      search.set("teamId", this.options.teamId);
+    }
+
+    const url = `https://api.vercel.com/v6/deployments?${search.toString()}`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: this.headers(),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Failed to list Vercel deployments (${response.status}): ${text || response.statusText}`
+      );
+    }
+
+    const payload = (await response.json()) as {
+      deployments?: Array<{
+        uid?: string;
+        id?: string;
+        url?: string;
+        createdAt?: number;
+        created_at?: number;
+        meta?: Record<string, string>;
+      }>;
+    };
+    const deployments = payload.deployments ?? [];
+
+    const matches = deployments
+      .filter((deployment) => {
+        const meta = deployment.meta ?? {};
+        const candidates = [
+          meta["githubCommitRef"],
+          meta["githubPrHeadBranch"],
+          meta["branch"],
+        ].filter(Boolean);
+        return candidates.includes(branch);
+      })
+      .sort((a, b) => {
+        const aTime = a.createdAt ?? a.created_at ?? 0;
+        const bTime = b.createdAt ?? b.created_at ?? 0;
+        return bTime - aTime;
+      });
+
+    const candidate = matches[0];
+    if (!candidate) {
+      return null;
+    }
+
+    const deploymentId = candidate.uid ?? candidate.id;
+    if (!deploymentId) {
+      return null;
+    }
+
+    return {
+      id: deploymentId,
+      url: normalizeDeploymentUrl(candidate.url),
+      createdAt: candidate.createdAt ?? candidate.created_at,
+    };
+  }
+
+  async setAlias(domain: string, deploymentId: string): Promise<void> {
+    const url = this.buildUrl("/v2/aliases");
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        ...this.headers(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        alias: domain,
+        deploymentId,
+        projectId: this.options.projectId,
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Failed to assign alias (${response.status}): ${text || response.statusText}`
+      );
+    }
+  }
+
+  private buildUrl(path: string): string {
+    const url = new URL(`https://api.vercel.com${path}`);
+    if (this.options.teamId) {
+      url.searchParams.set("teamId", this.options.teamId);
+    }
+    return url.toString();
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.options.token}`,
+      "User-Agent": "runway-compass-staging-alias",
+    };
+  }
+}
+
+function parseInteger(name: string, value: string | undefined): number {
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`Invalid integer for ${name}: ${value}`);
+  }
+  return parsed;
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim() === "") {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+export async function run(): Promise<void> {
+  const githubToken = requireEnv("GITHUB_TOKEN");
+  const issueNumber = parseInteger("ISSUE_NUMBER", process.env.ISSUE_NUMBER);
+  const prNumber = parseInteger("PR_NUMBER", process.env.PR_NUMBER);
+  const repoOwner = requireEnv("REPO_OWNER");
+  const repoName = requireEnv("REPO_NAME");
+  const commentAuthor = requireEnv("COMMENT_AUTHOR");
+  const commentBody = requireEnv("COMMENT_BODY");
+  const aliasDomain = requireEnv("VERCEL_ALIAS_DOMAIN");
+  const vercelToken = requireEnv("VERCEL_TOKEN");
+  const vercelProjectId = requireEnv("VERCEL_PROJECT_ID");
+  const vercelTeamId = process.env.VERCEL_TEAM_ID?.trim() || undefined;
+
+  if (!isAliasCommand(commentBody)) {
+    // Defensive: allow workflow to call script even if guard misfires.
+    return;
+  }
+
+  const github = new RestGitHubClient({
+    token: githubToken,
+    owner: repoOwner,
+    repo: repoName,
+    issueNumber,
+    pullNumber: prNumber,
+  });
+  const vercel = new RestVercelClient({
+    token: vercelToken,
+    projectId: vercelProjectId,
+    teamId: vercelTeamId,
+  });
+
+  const hasAccess = await checkWriteAccess(github, {
+    owner: repoOwner,
+    repo: repoName,
+    username: commentAuthor,
+  });
+
+  if (!hasAccess) {
+    await github.createComment(
+      formatFailureComment({
+        requestor: commentAuthor,
+        reason:
+          "Only collaborators with at least write access can update the staging alias.",
+      })
+    );
+    return;
+  }
+
+  const prInfo = await github.getPullRequest(prNumber);
+  const branch = prInfo.head.ref;
+
+  try {
+    const result = await aliasLatestPreview({
+      branch,
+      aliasDomain,
+      vercelClient: vercel,
+    });
+
+    await github.createComment(
+      formatSuccessComment({
+        requestor: commentAuthor,
+        aliasDomain,
+        deploymentUrl: result.deploymentUrl,
+      })
+    );
+  } catch (error) {
+    process.exitCode = 1;
+
+    if (error instanceof MissingDeploymentError) {
+      await github.createComment(
+        formatFailureComment({
+          requestor: commentAuthor,
+          reason: `No ready Vercel preview deployment found for branch \`${branch}\`. Try redeploying the preview or rerun CI.`,
+        })
+      );
+      return;
+    }
+
+    if (error instanceof AliasFailedError) {
+      const details: string[] = [
+        `Failed to alias deployment \`${error.attemptedDeploymentId}\`: ${error.message}`,
+      ];
+      if (error.rollbackRestored === true) {
+        details.push("Rolled back to the previous deployment successfully.");
+      } else if (error.previousDeploymentId) {
+        details.push(
+          `Rollback to previous deployment \`${error.previousDeploymentId}\` failed; please fix manually in Vercel.`
+        );
+      }
+
+      await github.createComment(
+        formatFailureComment({
+          requestor: commentAuthor,
+          reason: details.join(" "),
+        })
+      );
+      return;
+    }
+
+    const message =
+      error instanceof Error ? error.message : "Unknown error occurred.";
+
+    await github.createComment(
+      formatFailureComment({
+        requestor: commentAuthor,
+        reason: message,
+      })
+    );
+  }
+}
+
+if (require.main === module) {
+  run().catch((error) => {
+    process.exitCode = 1;
+    console.error(error);
+  });
+}

--- a/tests/alias-staging.test.cjs
+++ b/tests/alias-staging.test.cjs
@@ -1,0 +1,181 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: "commonjs",
+  moduleResolution: "node",
+  esModuleInterop: true,
+  target: "ES2019",
+});
+require("ts-node/register");
+
+const {
+  isAliasCommand,
+  checkWriteAccess,
+  aliasLatestPreview,
+  formatSuccessComment,
+  formatFailureComment,
+  MissingDeploymentError,
+  AliasFailedError,
+} = require("../scripts/alias-staging");
+
+test("isAliasCommand returns true only for the exact trigger", () => {
+  assert.equal(isAliasCommand("/alias this"), true);
+  assert.equal(isAliasCommand(" /alias this "), true);
+  assert.equal(isAliasCommand("/ALIAS THIS"), false);
+  assert.equal(isAliasCommand("/alias that"), false);
+});
+
+test("checkWriteAccess returns true only for write-level permissions", async () => {
+  const allowed = ["write", "maintain", "admin"];
+  for (const level of allowed) {
+    const client = {
+      async getCollaboratorPermissionLevel() {
+        return level;
+      },
+    };
+    const hasAccess = await checkWriteAccess(client, {
+      owner: "runway",
+      repo: "compass",
+      username: "paulo",
+    });
+    assert.equal(hasAccess, true);
+  }
+
+  const denied = ["read", "triage", "none"];
+  for (const level of denied) {
+    const client = {
+      async getCollaboratorPermissionLevel() {
+        return level;
+      },
+    };
+    const hasAccess = await checkWriteAccess(client, {
+      owner: "runway",
+      repo: "compass",
+      username: "guest",
+    });
+    assert.equal(hasAccess, false);
+  }
+});
+
+test("aliasLatestPreview returns deployment info and updates alias", async () => {
+  const calls = [];
+  const vercelClient = {
+    async getCurrentAlias(domain) {
+      calls.push(["current", domain]);
+      return { deploymentId: "dpl_old", url: "https://dpl-old.vercel.app" };
+    },
+    async getLatestDeploymentForBranch(branch) {
+      calls.push(["latest", branch]);
+      return {
+        id: "dpl_123",
+        url: "https://dpl-123.vercel.app",
+      };
+    },
+    async setAlias(domain, deploymentId) {
+      calls.push(["set", domain, deploymentId]);
+    },
+  };
+
+  const result = await aliasLatestPreview({
+    branch: "feature/awesome",
+    vercelClient,
+    aliasDomain: "staging.example.com",
+  });
+
+  assert.deepEqual(calls, [
+    ["current", "staging.example.com"],
+    ["latest", "feature/awesome"],
+    ["set", "staging.example.com", "dpl_123"],
+  ]);
+  assert.equal(result.deploymentId, "dpl_123");
+  assert.equal(result.previousDeploymentId, "dpl_old");
+  assert.equal(result.deploymentUrl, "https://dpl-123.vercel.app");
+});
+
+test("aliasLatestPreview throws MissingDeploymentError if none found", async () => {
+  const vercelClient = {
+    async getCurrentAlias() {
+      return { deploymentId: "dpl_old" };
+    },
+    async getLatestDeploymentForBranch() {
+      return null;
+    },
+    async setAlias() {
+      throw new Error("should not run");
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      aliasLatestPreview({
+        branch: "feature/missing",
+        vercelClient,
+        aliasDomain: "staging.example.com",
+      }),
+    (error) => error instanceof MissingDeploymentError
+  );
+});
+
+test("aliasLatestPreview rolls back when alias update fails", async () => {
+  const calls = [];
+  const vercelClient = {
+    async getCurrentAlias(domain) {
+      calls.push(["current", domain]);
+      return { deploymentId: "dpl_old" };
+    },
+    async getLatestDeploymentForBranch(branch) {
+      calls.push(["latest", branch]);
+      return { id: "dpl_new", url: "https://dpl-new.vercel.app" };
+    },
+    async setAlias(domain, deploymentId) {
+      calls.push(["set", domain, deploymentId]);
+      if (deploymentId === "dpl_new") {
+        throw new Error("alias failed");
+      }
+      return undefined;
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      aliasLatestPreview({
+        branch: "feature/bad",
+        vercelClient,
+        aliasDomain: "staging.example.com",
+      }),
+    (error) => {
+      assert.ok(error instanceof AliasFailedError);
+      assert.equal(error.rollbackRestored, true);
+      return true;
+    }
+  );
+
+  assert.deepEqual(calls, [
+    ["current", "staging.example.com"],
+    ["latest", "feature/bad"],
+    ["set", "staging.example.com", "dpl_new"],
+    ["set", "staging.example.com", "dpl_old"],
+  ]);
+});
+
+test("formatSuccessComment includes alias and deployment details", () => {
+  const message = formatSuccessComment({
+    aliasDomain: "staging.runway.test",
+    deploymentUrl: "https://deploy.vercel.app",
+    requestor: "paulo",
+  });
+  assert.match(message, /@paulo/);
+  assert.match(message, /staging\.runway\.test/);
+  assert.match(message, /https:\/\/deploy\.vercel\.app/);
+});
+
+test("formatFailureComment highlights reason", () => {
+  const message = formatFailureComment({
+    requestor: "paulo",
+    reason: "No preview deployment found.",
+  });
+  assert.match(message, /@paulo/);
+  assert.match(message, /No preview deployment found/);
+});


### PR DESCRIPTION
## Summary
- add GitHub Action `PR Staging Alias` that listens for `/alias this` comments on pull requests and runs against the default branch
- introduce `scripts/alias-staging.ts` to verify commenter permissions, locate the latest READY Vercel preview for the PR head branch, and update the staging alias with rollback protection
- add Node test coverage for the command parsing, auth gating, success/error comment formatting, and rollback handling

## Testing
- npm run lint
- npm test

Closes #28
