### PR TITLE
feat: enrich staging alias workflow ux

### DIFF
--- a/.github/workflows/pr-alias.yml
+++ b/.github/workflows/pr-alias.yml
@@ -9,14 +9,15 @@ permissions:
   issues: write
   pull-requests: read
   contents: read
-  deployments: read
+  deployments: write
+  reactions: write
   actions: read
 
 jobs:
   alias-staging:
     if: >
       github.event.issue.pull_request != null &&
-      github.event.comment.body == '/alias this'
+      github.event.comment.body == '/alias to staging'
     runs-on: ubuntu-latest
     env:
       TS_NODE_COMPILER_OPTIONS: '{"module":"commonjs","moduleResolution":"node","esModuleInterop":true}'
@@ -41,10 +42,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
           COMMENT_BODY: ${{ github.event.comment.body }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}


### PR DESCRIPTION
## Summary
- switch the `/alias` workflow to listen for `/alias to staging`, react immediately, and manage GitHub Deployments for status instead of success comments
- extend `scripts/alias-staging.ts` with deployment + reaction helpers, introduce `runAliasFlow`, and keep failure comments as fallback
- tighten tests to cover the new command parsing, deployment lifecycle, and failure reporting behaviours

## Testing
- npm run lint
- npm test

Closes #28
