### PR TITLE
fix: allow staging alias workflow to load

### DIFF
--- a/.github/workflows/pr-alias.yml
+++ b/.github/workflows/pr-alias.yml
@@ -10,7 +10,6 @@ permissions:
   pull-requests: read
   contents: read
   deployments: write
-  reactions: write
   actions: read
 
 jobs:


### PR DESCRIPTION
## Summary
- remove unsupported `reactions` permission from workflow-level block so GitHub accepts the YAML
- rely on existing `issues: write` scope to add reactions

## Testing
- npm run lint (warn-only)
- npm test -- tests/alias-staging.test.cjs