### PR TITLE
fix: trust associations and allow status comments

### DIFF
--- a/.github/workflows/pr-alias.yml
+++ b/.github/workflows/pr-alias.yml
@@ -42,6 +42,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           PR_NUMBER: ${{ github.event.issue.number }}
           COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}


### PR DESCRIPTION
## Summary
- thread `COMMENT_AUTHOR_ASSOCIATION` into the TypeScript runner so OWNER/MEMBER/COLLABORATOR commenters skip the collaborator permission API
- wrap GitHub comment posting in a safe helper to avoid hard failures when comment creation is blocked
- bump workflow permissions to `pull-requests: write` so the default token can leave fallback comments
- extend tests for association shortcuts, unauthorized flows, and comment handling

## Testing
- npm test -- tests/alias-staging.test.cjs
