### PR TITLE
fix: log alias failures and relax comment requirements

### DIFF
--- a/.github/workflows/pr-alias.yml
+++ b/.github/workflows/pr-alias.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
   contents: read
   deployments: write
   actions: read

--- a/tests/alias-staging.test.cjs
+++ b/tests/alias-staging.test.cjs
@@ -13,12 +13,12 @@ require("ts-node/register");
 const {
   isAliasCommand,
   checkWriteAccess,
+  verifyWriteAccess,
   aliasLatestPreview,
   formatFailureComment,
   MissingDeploymentError,
   AliasFailedError,
   runAliasFlow,
-  verifyWriteAccess,
 } = require("../scripts/alias-staging");
 
 test("isAliasCommand returns true only for the exact trigger", () => {
@@ -60,10 +60,12 @@ test("checkWriteAccess returns true only for write-level permissions", async () 
   }
 });
 
-test("verifyWriteAccess honors association before API call", async () => {
+test("verifyWriteAccess allows trusted associations without API call", async () => {
+  let called = false;
   const client = {
     async getCollaboratorPermissionLevel() {
-      throw new Error("should not call API");
+      called = true;
+      return "none";
     },
   };
 
@@ -75,9 +77,10 @@ test("verifyWriteAccess honors association before API call", async () => {
   });
 
   assert.equal(hasAccess, true);
+  assert.equal(called, false);
 });
 
-test("verifyWriteAccess falls back to API when association unknown", async () => {
+test("verifyWriteAccess falls back to API when association is untrusted", async () => {
   const client = {
     async getCollaboratorPermissionLevel() {
       return "write";
@@ -383,13 +386,13 @@ test("runAliasFlow denies commenters without write association", async () => {
       events.push(["reaction", commentId, reaction]);
     },
     async getPullRequest() {
-      throw new Error("should not fetch PR for unauthorized users");
+      throw new Error("should not fetch PR for unauthorized user");
     },
     async createDeployment() {
       throw new Error("should not create deployment");
     },
     async setDeploymentStatus() {
-      throw new Error("should not set deployment status");
+      throw new Error("should not set status");
     },
     async createComment(body) {
       events.push(["comment", body]);
@@ -398,13 +401,13 @@ test("runAliasFlow denies commenters without write association", async () => {
 
   const vercelClient = {
     async getCurrentAlias() {
-      throw new Error("should not query vercel");
+      throw new Error("should not call Vercel");
     },
     async getLatestDeploymentForBranch() {
-      throw new Error("should not query vercel");
+      throw new Error("should not call Vercel");
     },
     async setAlias() {
-      throw new Error("should not query vercel");
+      throw new Error("should not call Vercel");
     },
   };
 


### PR DESCRIPTION
## Summary
- add trusted association shortcut so owners/members skip the collaborator-permission REST call
- wrap GitHub comment posting in a safe helper and log underlying alias errors before attempting feedback
- bump workflow permissions to `pull-requests: write` and pass `COMMENT_AUTHOR_ASSOCIATION` through to the script
- extend tests for association handling, unauthorized flows, and failure logging

## Testing
- npm test -- tests/alias-staging.test.cjs

Closes #28
