### PR TITLE
Format staging alias success link

### DIFF
--- a/scripts/alias-staging.ts
+++ b/scripts/alias-staging.ts
@@ -447,10 +447,11 @@ export function formatSuccessComment(params: {
 }): string {
   const { requestor, aliasDomain, deploymentUrl } = params;
   const target = deploymentUrl ?? `https://${aliasDomain}`;
+  const link = `[${target}](${target})`;
   return [
     `@${requestor} staging alias updated ✅`,
     "",
-    `\`${aliasDomain}\` now points to ${target}.`,
+    `\`${aliasDomain}\` now points to ${link}.`,
     "",
     "Happy testing!",
   ].join("\n");

--- a/tests/alias-staging.test.cjs
+++ b/tests/alias-staging.test.cjs
@@ -515,5 +515,5 @@ test("formatSuccessComment includes alias info", () => {
   });
   assert.match(comment, /paulo/);
   assert.match(comment, /staging.runway.test/);
-  assert.match(comment, /https:\/\/preview\.vercel\.app/);
+  assert.match(comment, /\[https:\/\/preview\.vercel\.app\]\(https:\/\/preview\.vercel\.app\)/);
 });


### PR DESCRIPTION
## Summary
- render the success comment with a markdown link so the preview URL is clickable

## Testing
- npm run lint
- npm test