### PR TITLE
Tweak alias reactions and deployment

### DIFF
--- a/scripts/alias-staging.ts
+++ b/scripts/alias-staging.ts
@@ -231,7 +231,7 @@ export async function runAliasFlow(params: {
     return "ignored";
   }
 
-  await attemptAsync(() => github.reactToComment(inputs.commentId, "+1"));
+  await attemptAsync(() => github.reactToComment(inputs.commentId, "eyes"));
 
   const hasAccess = await verifyWriteAccess(github, {
     owner: inputs.repoOwner,
@@ -253,12 +253,13 @@ export async function runAliasFlow(params: {
 
   const prInfo = await github.getPullRequest(inputs.pullNumber);
   const branch = prInfo.head.ref;
+  const headRef = prInfo.head.sha ?? prInfo.head.ref;
   const deploymentDescription = `Updating staging alias to latest preview for ${branch}`;
 
   let deploymentId: number | undefined;
   try {
     const deployment = await github.createDeployment({
-      ref: inputs.defaultBranch,
+      ref: headRef,
       environment: "staging",
       description: deploymentDescription,
       auto_merge: false,
@@ -381,6 +382,8 @@ export async function runAliasFlow(params: {
         })
       );
     }
+
+    await attemptAsync(() => github.reactToComment(inputs.commentId, "confused"));
 
     return "failure";
   }

--- a/tests/alias-staging.test.cjs
+++ b/tests/alias-staging.test.cjs
@@ -266,11 +266,11 @@ test("runAliasFlow reacts, creates deployment, and marks success", async () => {
   });
 
   assert.deepEqual(events, [
-    ["reaction", 77, "+1"],
+    ["reaction", 77, "eyes"],
     [
       "deployment",
       {
-        ref: "main",
+        ref: "feature/awesome",
         environment: "staging",
         description: "Updating staging alias to latest preview for feature/awesome",
         auto_merge: false,
@@ -316,8 +316,8 @@ test("runAliasFlow reports failure and updates deployment status", async () => {
     async getCollaboratorPermissionLevel() {
       return "write";
     },
-    async reactToComment() {
-      events.push(["reaction"]);
+    async reactToComment(_id, reaction) {
+      events.push(["reaction", reaction]);
     },
     async getPullRequest() {
       return { head: { ref: "feature/missing" } };
@@ -364,7 +364,7 @@ test("runAliasFlow reports failure and updates deployment status", async () => {
     },
   });
 
-  assert.equal(events[0][0], "reaction");
+  assert.deepEqual(events[0], ["reaction", "eyes"]);
   assert.equal(events[1][0], "deployment");
   assert.deepEqual(events[2], [
     "status",
@@ -381,6 +381,7 @@ test("runAliasFlow reports failure and updates deployment status", async () => {
   ]);
   assert.equal(events[4][0], "comment");
   assert.match(events[4][1], /No ready Vercel preview deployment found/);
+  assert.deepEqual(events[5], ["reaction", "confused"]);
 });
 
 test("runAliasFlow denies commenters without write association", async () => {
@@ -437,7 +438,7 @@ test("runAliasFlow denies commenters without write association", async () => {
   });
 
   assert.equal(outcome, "unauthorized");
-  assert.deepEqual(events[0], ["reaction", 5, "+1"]);
+  assert.deepEqual(events[0], ["reaction", 5, "eyes"]);
   assert.equal(events[1][0], "permission");
   assert.equal(events[2][0], "comment");
   assert.match(events[2][1], /write access/);


### PR DESCRIPTION
## Summary
- react with :eyes: when aliasing starts and :rocket: on success
- react with :confused: when aliasing fails
- create GitHub deployments against the PR head SHA for better integration

## Testing
- npm run lint
- npm test