### PR TITLE
chore: strip marketing blurb from home

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,29 +12,6 @@ import { SpreadsheetHealthPanel } from "@/components/spreadsheet/spreadsheet-hea
 import { CashPlannerManager } from "@/components/cash-planner/cash-planner-manager";
 import { RunwayTimeline } from "@/components/runway-timeline/runway-timeline";
 
-const featureItems = [
-  {
-    title: "Rolling budgets",
-    description:
-      "Capture annual allocations per category and carry unused funds forward automatically.",
-  },
-  {
-    title: "Balance snapshots",
-    description:
-      "Record the latest balances for bank accounts, digital wallets, and cash to stay grounded in reality.",
-  },
-  {
-    title: "Future events",
-    description:
-      "Log upcoming income or expenses—like benefits or travel—so runway projections stay honest.",
-  },
-  {
-    title: "Runway outlook",
-    description:
-      "Visualize month-by-month runway with clear green/yellow/red milestones for income, savings, and burn.",
-  },
-];
-
 export default async function Home() {
   const session = await requireSession();
   const displayName = session.user?.name ?? session.user?.email ?? "Account";
@@ -73,52 +50,6 @@ export default async function Home() {
         </div>
       </SpreadsheetHealthProvider>
 
-      <section className="flex flex-col gap-6 text-balance">
-        <span className="text-sm font-semibold uppercase tracking-wide accent-text">
-          Personal runway planning
-        </span>
-        <h1 className="text-4xl font-semibold sm:text-5xl">
-          Keep your 24-month cash runway clear, calm, and under control.
-        </h1>
-        <p className="max-w-2xl text-lg text-zinc-600 dark:text-zinc-300">
-          Runway Compass helps you connect a private Google Sheet to rolling
-          budgets, manual actuals, and future cash events so you always know how
-          many months of runway remain.
-        </p>
-        <div className="flex flex-wrap gap-3">
-          <span className="inline-flex items-center rounded-full bg-[color:var(--color-accent-muted)] px-4 py-1 text-sm font-medium text-[color:var(--color-accent-muted-foreground)] ring-1 ring-inset ring-[color:color-mix(in_srgb,var(--color-accent)_35%,#ede9fe_65%)] dark:bg-[color:color-mix(in_srgb,var(--color-accent)_24%,#0a0a0a_76%)] dark:text-[color:color-mix(in_srgb,var(--color-accent)_78%,#ede9fe_22%)] dark:ring-[color:color-mix(in_srgb,var(--color-accent)_55%,#1f1f1f_45%)]">
-            Next.js App Router
-          </span>
-          <span className="inline-flex items-center rounded-full bg-sky-100 px-4 py-1 text-sm font-medium text-sky-800 ring-1 ring-inset ring-sky-200">
-            Google Sheets as your database
-          </span>
-          <span className="inline-flex items-center rounded-full bg-zinc-100 px-4 py-1 text-sm font-medium text-zinc-700 ring-1 ring-inset ring-zinc-200">
-            Manual-first workflows
-          </span>
-        </div>
-      </section>
-
-      <section className="grid gap-6 sm:grid-cols-2">
-        {featureItems.map((feature) => (
-          <article
-            key={feature.title}
-            className="flex flex-col gap-2 rounded-2xl border border-zinc-200/70 bg-white/60 p-6 shadow-sm shadow-zinc-900/5 backdrop-blur dark:border-zinc-700/60 dark:bg-zinc-900/70"
-          >
-            <h2 className="text-xl font-semibold">{feature.title}</h2>
-            <p className="text-base text-zinc-600 dark:text-zinc-300">
-              {feature.description}
-            </p>
-          </article>
-        ))}
-      </section>
-
-      <section className="rounded-2xl border border-dashed accent-border accent-surface p-6 dark:bg-[color:color-mix(in_srgb,var(--color-accent)_22%,#0a0a0a_78%)] dark:text-[color:color-mix(in_srgb,var(--color-accent)_75%,#ede9fe_25%)]">
-        <h2 className="text-lg font-semibold">Up next</h2>
-        <p className="mt-2 text-base">
-          Milestone 1 will introduce Google sign-in, spreadsheet selection, and
-          the initial schema bootstrap so your data flows securely from day one.
-        </p>
-      </section>
     </main>
   );
 }

--- a/tests/authenticated-home-marketing.cjs
+++ b/tests/authenticated-home-marketing.cjs
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { readFileSync } = require("node:fs");
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+test("authenticated home has no marketing copy", () => {
+  const pagePath = path.join(__dirname, "../src/app/page.tsx");
+  const page = readFileSync(pagePath, "utf8");
+
+  const bannedPhrases = [
+    "Personal runway planning",
+    "Keep your 24-month cash runway clear",
+    "Runway Compass helps you connect a private Google Sheet",
+    "Milestone 1 will introduce Google sign-in",
+  ];
+
+  for (const phrase of bannedPhrases) {
+    assert.ok(
+      !page.includes(phrase),
+      `Expected marketing phrase to be removed: ${phrase}`,
+    );
+  }
+});


### PR DESCRIPTION
- Removed marketing hero, feature grid, and milestone teaser from authenticated home so only workspace controls render.
- Added regression test that fails if legacy marketing phrasing returns to the page.

## Test Plan
- npm test
- npm run lint