### PR TITLE
chore: ignore async task artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 next-env.d.ts
 .tmux-tasks/*
 !.tmux-tasks/.gitkeep
+/.async-tasks/


### PR DESCRIPTION
Adds /.async-tasks/ to .gitignore so tmux async runner output stays local.