### PR TITLE
chore: streamline async task ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,4 @@ yarn-error.log*
 .worktrees/
 *.tsbuildinfo
 next-env.d.ts
-.tmux-tasks/*
-!.tmux-tasks/.gitkeep
-/.async-tasks/
+.async-tasks/


### PR DESCRIPTION
Drops the unused tmux task ignore and keeps only /.async-tasks/.