### PR TITLE
chore: pin turbopack root to repo dir

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    // Pin Turbopack root to this checkout so nested worktrees don't conflict.
+    root: __dirname,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Sets next.config.ts turbopack.root to __dirname so worktree builds stay isolated.